### PR TITLE
fix: single price auction

### DIFF
--- a/Seq01_CalculateUsage.plantuml
+++ b/Seq01_CalculateUsage.plantuml
@@ -2,7 +2,6 @@
 database    UsageDatabase     as db1
 participant System            as sys
 participant Student1          as st1
-participant XRPLedger as xl
 
 sys --> db1 : request last year usage data
 db1 --> sys : send last year usage data

--- a/Seq02_GenerateToken.plantuml
+++ b/Seq02_GenerateToken.plantuml
@@ -2,8 +2,10 @@
 participant Student1          as st1
 participant System            as sys
 participant XRPLedger         as xl
+database TxDatabase as db2
 
 st1 --> sys : desired electoricity\n(solar or energy company )
 sys --> xl : request transaction\n(System to Student1)
 xl --> xl : add XRP token(Student1)\nremove XRP token(System)
+sys --> db2 : report transaction\n(price & amount) 
 @enduml

--- a/Seq03_StudentsTokenTransaction.plantuml
+++ b/Seq03_StudentsTokenTransaction.plantuml
@@ -5,8 +5,9 @@ participant System as sys
 participant XRPLedger as xl
 database TxDatabase as db2
 
-st1 --> sys : send ask(price & amount)
-st2 --> sys : accept Student1's ask
+st1 --> sys : send ask\n(price & amount)
+st2 --> sys : send bid\n(price & amount)
+sys --> sys : calculate winning bid
 sys --> xl : request transaction\n(Student2 to Student1)
 xl --> xl : add XRP token(Student1)\nremove XRP token(Student2)
 sys --> db2 : report transaction\n(price & amount) 

--- a/Seq04_AddIssueToken.plantuml
+++ b/Seq04_AddIssueToken.plantuml
@@ -3,10 +3,12 @@ participant Student1 as st1
 participant System as sys
 participant EnergyCompany as ec
 participant XRPLedger as xl
+database TxDatabase as db2
 
 st1 --> sys : request more electricity
 sys --> ec : buy electricity
 ec --> sys : provide electricity
 sys --> xl : request to send token to Student 
 xl --> xl : add XRP token(Student1)\nremove XRP token(System)
+sys --> db2 : report transaction\n(price & amount) 
 @enduml

--- a/Seq05_ShowMarketdata.plantuml
+++ b/Seq05_ShowMarketdata.plantuml
@@ -3,5 +3,5 @@ participant Student1 as st1
 database TxDatabase as db2
 
 st1 --> db2 : requst market data
-st1 <-- db2 : send market data(daily close)
+st1 <-- db2 : send market data(daily winning bid)
 @enduml

--- a/Seq08_AdjustmentToken.plantuml
+++ b/Seq08_AdjustmentToken.plantuml
@@ -3,13 +3,16 @@ participant System   as sys
 participant XRPLedger as xl
 participant Student1 as st1
 participant Student2 as st2
+database TxDatabase as db2
 
 sys --> xl : inquiry student's token balance
 xl --> sys : send data(student's token balance)
 sys --> st1 : buy Student1's long token 
 sys --> xl : request transaction(Stundent1 to System)
 xl --> xl : add XRP token(System)\nremove XRP token(Student1)
+sys --> db2 : report transaction\n(price & amount) 
 sys --> st2 : sell Student2's short token 
 sys --> xl : request transaction(System to Student2)
 xl --> xl : add XRP token(Student2)\nremove XRP token(System)
+sys --> db2 : report transaction\n(price & amount)
 @enduml

--- a/Seq09_MonthEndAccounting.plantuml
+++ b/Seq09_MonthEndAccounting.plantuml
@@ -8,5 +8,5 @@ sa --> db1 : request usage data in network
 sa <-- db1 : send usage data in network
 sa --> db2 : request market data
 sa <-- db2 : send market data
-sa --> ua : report monthly data in newwork
+sa --> ua : report monthly data in network
 @enduml


### PR DESCRIPTION
シーケンス図をBidのみの取引から、シングルプライスオークション方式での取引に変更
その他、Tx Databaseに取引を記録していないシーケンス図があったので修正