### PR TITLE
Common

### DIFF
--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,0 +1,1 @@
+export * as proto from './proto';

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -64,5 +64,6 @@
     /* Advanced Options */
     //"skipLibCheck": true                    /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
これにより

```
import * as proto from '@local/common/esm/proto'
```

ではなく

```
import { proto } from '@local/common'
```

でしかもprotoで補完でるようになる