### PR TITLE
fix: button color by css

### DIFF
--- a/projects/main/src/app/view/txs/buy/buy.component.css
+++ b/projects/main/src/app/view/txs/buy/buy.component.css
@@ -1,0 +1,11 @@
+.mdc-button--raised:not(:disabled) {
+  width: 50%;
+  min-width: 200px;
+  max-width: 600px;
+  font-size: 1.875rem /* 30px */;
+  line-height: 2.25rem /* 36px */;
+  height: 4.5rem;
+  line-height: 4.5rem;
+  color: #000000;
+  background-color: #bfdbfe;
+}

--- a/projects/main/src/app/view/txs/sell/sell.component.css
+++ b/projects/main/src/app/view/txs/sell/sell.component.css
@@ -1,0 +1,11 @@
+.mdc-button--raised:not(:disabled) {
+  width: 50%;
+  min-width: 200px;
+  max-width: 600px;
+  font-size: 1.875rem /* 30px */;
+  line-height: 2.25rem /* 36px */;
+  height: 4.5rem;
+  line-height: 4.5rem;
+  color: #000000;
+  background-color: #bfdbfe;
+}


### PR DESCRIPTION
ボタンのカラーについて，
公式ドキュメントによればSassで変更することが可能で，CSSでも可能
https://material.io/components/buttons/web#api

今回は以下参考にCSSでサイズと色を変更
https://stackoverflow.com/questions/51684345/change-container-fill-colour-for-mdc-button/51684487

文字の大きさ等は他のものに合わせてます

@KimuraYu45z @Tomosuke0930 
問題点ごとに分けたのでPRが複数に分かれていますが，レビューお願いします。
