### PR TITLE
Signup enhance

### DIFF
--- a/projects/main/src/app/page/accounts/create/create.component.ts
+++ b/projects/main/src/app/page/accounts/create/create.component.ts
@@ -13,7 +13,6 @@ export class CreateComponent implements OnInit {
   ngOnInit(): void {}
 
   async onSubmit($event: CreateOnSubmitEvent) {
-    console.log($event.mail, $event.password, $event.name);
     this.auth.signup(
       {
         type: 'email',

--- a/projects/main/src/app/view/accounts/create/create.component.html
+++ b/projects/main/src/app/view/accounts/create/create.component.html
@@ -1,79 +1,66 @@
-<div class="text-center">
+<div class="flex flex-col w-96">
   <h2>Sign Up</h2>
   <h3>SIGN UP ACCOUNT</h3>
-  <mat-card>
-    <form #formRef="ngForm" (submit)="onSubmit(nameRef.value, mailRef.value, passwordRef.value, passwordConfirmationRef.value)">
-      <mat-form-field>
-        <mat-label>Input Name</mat-label>
-        <input
-          #nameRef
-          ngModel
-          name="name"
-          matInput
-          required
-          placeholder="Input value"
-          pattern="^[a-zA-Z0-9_][a-z_0-9]*$"
-          autocomplete="username"
-        />
-      </mat-form-field>
+  <form #formRef="ngForm" (submit)="onSubmit(nameRef.value, mailRef.value, passwordRef.value, passwordConfirmationRef.value)">
+    <mat-form-field class="w-full">
+      <mat-label>Input Name</mat-label>
+      <input #nameRef ngModel name="name" matInput required placeholder="Input value" minlength="4" />
+    </mat-form-field>
+    <br />
+    <mat-form-field class="w-full">
+      <mat-label>Input Email</mat-label>
+      <input
+        #mailRef
+        ngModel
+        name="mail"
+        matInput
+        required
+        placeholder="Input value"
+        pattern="^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$"
+      />
+    </mat-form-field>
+    <br />
+    <mat-form-field class="w-full">
+      <mat-label>Input Password</mat-label>
+      <input
+        #passwordRef
+        ngModel
+        [type]="isPasswordVisible ? 'text' : 'password'"
+        name="password"
+        matInput
+        required
+        placeholder="Input value"
+        minlength="8"
+      />
+      <button mat-button type="button" matSuffix (click)="togglePasswordVisibility()">
+        <mat-icon>
+          {{ isPasswordVisible ? 'visibility' : 'visibility_off' }}
+        </mat-icon>
+      </button>
+    </mat-form-field>
+    <br />
+    <mat-form-field class="w-full">
+      <mat-label>Input Password Again</mat-label>
+      <input
+        #passwordConfirmationRef
+        ngModel
+        [type]="isPasswordVisible ? 'text' : 'password'"
+        name="passwordConfirmation"
+        matInput
+        required
+        placeholder="Input value"
+        minlength="8"
+      />
+      <button mat-button type="button" matSuffix (click)="togglePasswordVisibility()">
+        <mat-icon>
+          {{ isPasswordVisible ? 'visibility' : 'visibility_off' }}
+        </mat-icon>
+      </button>
+    </mat-form-field>
+    <div class="flex flex-row">
+      <span class="flex-auto"> </span>
       <br />
-      <mat-form-field>
-        <mat-label>Input Email</mat-label>
-        <input
-          #mailRef
-          ngModel
-          name="mail"
-          matInput
-          required
-          placeholder="Input value"
-          pattern="^[a-zA-Z0-9_+-]+(.[a-zA-Z0-9_+-]+)*@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.)+[a-zA-Z]{2,}$"
-        />
-      </mat-form-field>
-      <br />
-      <mat-form-field>
-        <mat-label>Input Password</mat-label>
-        <input
-          #passwordRef
-          ngModel
-          [type]="isPasswordVisible ? 'text' : 'password'"
-          name="password"
-          matInput
-          required
-          placeholder="Input value"
-          minlength="8"
-        />
-        <button mat-button type="button" matSuffix (click)="togglePasswordVisibility()">
-          <mat-icon>
-            {{ isPasswordVisible ? 'visibility' : 'visibility_off' }}
-          </mat-icon>
-        </button>
-      </mat-form-field>
-      <br />
-      <mat-form-field>
-        <mat-label>Input Password Again</mat-label>
-        <input
-          #passwordConfirmationRef
-          ngModel
-          [type]="isPasswordVisible ? 'text' : 'password'"
-          name="passwordConfirmation"
-          matInput
-          required
-          placeholder="Input value"
-          minlength="8"
-        />
-        <button mat-button type="button" matSuffix (click)="togglePasswordVisibility()">
-          <mat-icon>
-            {{ isPasswordVisible ? 'visibility' : 'visibility_off' }}
-          </mat-icon>
-        </button>
-      </mat-form-field>
-      <br />
-      <!-- <mat-radio-group class="flex">
-      <mat-radio-button class="mr-4" value="student">Student</mat-radio-button>
-      <mat-radio-button value="administrator">Administrator</mat-radio-button>
-    </mat-radio-group>
-    <br /> -->
       <button mat-flat-button color="primary" type="submit" [disabled]="formRef.invalid">Sign Up</button>
-    </form>
-  </mat-card>
+    </div>
+  </form>
 </div>

--- a/projects/shared/src/lib/services/auth/auth.application.service.ts
+++ b/projects/shared/src/lib/services/auth/auth.application.service.ts
@@ -2,7 +2,15 @@ import { ChangeEmailError, ChangePasswordError, ResetPasswordError, SignInError,
 import { AuthService } from './auth.service';
 import { Location } from '@angular/common';
 import { Injectable } from '@angular/core';
-import { Auth, GoogleAuthProvider, FacebookAuthProvider, sendPasswordResetEmail, updateEmail, updatePassword } from '@angular/fire/auth';
+import {
+  Auth,
+  GoogleAuthProvider,
+  FacebookAuthProvider,
+  sendPasswordResetEmail,
+  updateEmail,
+  updatePassword,
+  sendEmailVerification,
+} from '@angular/fire/auth';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { Account, User } from '@local/common';
@@ -87,6 +95,31 @@ export class AuthApplicationService {
       return;
     } finally {
       dialogRef.close();
+    }
+
+    const dialogRef2 = this.loadingDialog.open('アカウントを確認するためのメールを送信しています');
+    try {
+      await sendEmailVerification(this.auth.currentUser!);
+    } catch (error) {
+      switch ((error as ResetPasswordError).code) {
+        case 'auth/user-not-found':
+          this.snackBar.open('登録されていないユーザーです。', undefined, {
+            duration: 6000,
+          });
+          break;
+        case 'auth/wrong-password':
+          this.snackBar.open('パスワードが間違っています', undefined, {
+            duration: 6000,
+          });
+          break;
+        case 'auth/invalid-email':
+          this.snackBar.open('無効なメールアドレスです。', undefined, {
+            duration: 6000,
+          });
+          break;
+      }
+    } finally {
+      dialogRef2.close();
     }
 
     this.location.back();


### PR DESCRIPTION
close #95 

サインアップ時にアカウント確認メールを送信する機能の実装。
認証すると`getAuth().currentUser.emailVerified`がtrueになる。

![emailvarif](https://user-images.githubusercontent.com/29295263/142170197-cc0af779-15e6-4833-801c-8255237cede4.PNG)

現状これがないと使えない機能はないが、Tx系にはemailVerifiedGuardを付けてもいいと考えてます。