### PR TITLE
add ask type

### DIFF
--- a/functions/src/normal-settlements/normal-settlement.ts
+++ b/functions/src/normal-settlements/normal-settlement.ts
@@ -5,7 +5,7 @@ import { normal_ask } from '../normal-asks';
 import { normal_bid_history } from '../normal-bid-histories';
 import { normal_bid } from '../normal-bids';
 import { single_price_normal_settlement } from '../single-price-normal-settlements';
-import { NormalAskHistory, NormalBidHistory, NormalSettlement } from '@local/common';
+import { NormalAskHistory, NormalBidHistory, NormalSettlement, proto } from '@local/common';
 
 single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) => {
   const data = snapshot.data()!;
@@ -37,6 +37,7 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
       for (; j < sortNormalAsks.length; j++) {
         await normal_ask_history.create(
           new NormalAskHistory({
+            type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
             account_id: sortNormalAsks[j].account_id,
             price: sortNormalAsks[j].price,
             amount: sortNormalAsks[j].amount,
@@ -71,6 +72,7 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
 
       await normal_ask_history.create(
         new NormalAskHistory({
+          type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
           account_id: sortNormalAsks[j].account_id,
           price: sortNormalAsks[j].price,
           amount: sortNormalBids[i].amount,
@@ -105,6 +107,7 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
 
       await normal_ask_history.create(
         new NormalAskHistory({
+          type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
           account_id: sortNormalAsks[j].account_id,
           price: sortNormalAsks[j].price,
           amount: sortNormalAsks[j].amount,
@@ -140,6 +143,7 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
 
       await normal_ask_history.create(
         new NormalAskHistory({
+          type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
           account_id: sortNormalAsks[j].account_id,
           price: sortNormalAsks[j].price,
           amount: sortNormalBids[i].amount,

--- a/functions/src/renewable-settlements/renewable-settlement.ts
+++ b/functions/src/renewable-settlements/renewable-settlement.ts
@@ -5,7 +5,7 @@ import { renewable_ask } from '../renewable-asks';
 import { renewable_bid_history } from '../renewable-bid-histories';
 import { renewable_bid } from '../renewable-bids';
 import { single_price_renewable_settlement } from '../single-price-renewable-settlements';
-import { RenewableAskHistory, RenewableBidHistory, RenewableSettlement } from '@local/common';
+import { proto, RenewableAskHistory, RenewableBidHistory, RenewableSettlement } from '@local/common';
 
 single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context) => {
   const data = snapshot.data()!;
@@ -37,6 +37,7 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
       for (; j < sortRenewableAsks.length; j++) {
         await renewable_ask_history.create(
           new RenewableAskHistory({
+            type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
             account_id: sortRenewableAsks[j].account_id,
             price: sortRenewableAsks[j].price,
             amount: sortRenewableAsks[j].amount,
@@ -71,6 +72,7 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
 
       await renewable_ask_history.create(
         new RenewableAskHistory({
+          type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
           account_id: sortRenewableAsks[j].account_id,
           price: sortRenewableAsks[j].price,
           amount: sortRenewableBids[i].amount,
@@ -105,6 +107,7 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
 
       await renewable_ask_history.create(
         new RenewableAskHistory({
+          type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
           account_id: sortRenewableAsks[j].account_id,
           price: sortRenewableAsks[j].price,
           amount: sortRenewableAsks[j].amount,
@@ -140,6 +143,7 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
 
       await renewable_ask_history.create(
         new RenewableAskHistory({
+          type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
           account_id: sortRenewableAsks[j].account_id,
           price: sortRenewableAsks[j].price,
           amount: sortRenewableBids[i].amount,

--- a/projects/main/src/app/page/txs/sell/sell.component.ts
+++ b/projects/main/src/app/page/txs/sell/sell.component.ts
@@ -1,7 +1,7 @@
 import { SellOnSubmitEvent } from '../../../view/txs/sell/sell.component';
 import { Component, OnInit } from '@angular/core';
 import { getAuth } from '@angular/fire/auth';
-import { AvailableBalance, NormalAsk, RenewableAsk } from '@local/common';
+import { AvailableBalance, NormalAsk, proto, RenewableAsk } from '@local/common';
 import { NormalAskApplicationService } from 'projects/shared/src/lib/services/normal-asks/normal-ask.application.service';
 import { RenewableAskApplicationService } from 'projects/shared/src/lib/services/renewable-asks/renewable-ask.application.service';
 import { AvailableBalanceApplicationService } from 'projects/shared/src/lib/services/student-accounts/available-balances/available-balance.application.service';
@@ -37,6 +37,7 @@ export class SellComponent implements OnInit {
     if ($event.denom == 'spx-1') {
       await this.renewableAskApp.create(
         new RenewableAsk({
+          type: proto.main.RenewableAskType.SECONDARY,
           account_id: getAuth().currentUser?.uid,
           price: $event.price,
           amount: $event.amount,
@@ -45,6 +46,7 @@ export class SellComponent implements OnInit {
     } else {
       await this.normalAskApp.create(
         new NormalAsk({
+          type: proto.main.NormalAskType.SECONDARY,
           account_id: getAuth().currentUser?.uid,
           price: $event.price,
           amount: $event.amount,


### PR DESCRIPTION
フロントからNormal AskとRenewable Askの作成時にTypeを付与する機能を追加
HistoryにしたときにもTypeをそのまま残す仕様に変更。利用者はSecondary以外のAskをそもそも作れないのでこれによるフロントの変更は現状変更なし