### PR TITLE
Bid, Askの作成時刻のHistoryへの記録

### DIFF
--- a/common/src/entities/normal-ask-histories/normal-ask-history.ts
+++ b/common/src/entities/normal-ask-histories/normal-ask-history.ts
@@ -2,7 +2,12 @@ import { proto } from '../..';
 import { FieldValue, Timestamp } from 'firebase/firestore';
 
 export class NormalAskHistory extends proto.main.NormalAskHistory {
-  constructor(iNormalAskHistory: proto.main.INormalAskHistory, public created_at?: FieldValue | Timestamp, public updated_at?: FieldValue | Timestamp) {
+  constructor(
+    iNormalAskHistory: proto.main.INormalAskHistory,
+    public ask_created_at?: FieldValue | Timestamp,
+    public created_at?: FieldValue | Timestamp,
+    public updated_at?: FieldValue | Timestamp,
+  ) {
     super(iNormalAskHistory);
   }
 

--- a/common/src/entities/normal-bid-histories/normal-bid-history.ts
+++ b/common/src/entities/normal-bid-histories/normal-bid-history.ts
@@ -2,7 +2,12 @@ import { proto } from '../..';
 import { FieldValue, Timestamp } from 'firebase/firestore';
 
 export class NormalBidHistory extends proto.main.NormalBidHistory {
-  constructor(iNormalBidHistory: proto.main.INormalBidHistory, public created_at?: FieldValue | Timestamp, public updated_at?: FieldValue | Timestamp) {
+  constructor(
+    iNormalBidHistory: proto.main.INormalBidHistory,
+    public bid_created_at?: FieldValue | Timestamp,
+    public created_at?: FieldValue | Timestamp,
+    public updated_at?: FieldValue | Timestamp,
+  ) {
     super(iNormalBidHistory);
   }
 

--- a/common/src/entities/renewable-ask-histories/renewable-ask-history.ts
+++ b/common/src/entities/renewable-ask-histories/renewable-ask-history.ts
@@ -2,7 +2,12 @@ import { proto } from '../..';
 import { FieldValue, Timestamp } from 'firebase/firestore';
 
 export class RenewableAskHistory extends proto.main.RenewableAskHistory {
-  constructor(iRenewableAskHistory: proto.main.IRenewableAskHistory, public created_at?: FieldValue | Timestamp, public updated_at?: FieldValue | Timestamp) {
+  constructor(
+    iRenewableAskHistory: proto.main.IRenewableAskHistory,
+    public ask_created_at?: FieldValue | Timestamp,
+    public created_at?: FieldValue | Timestamp,
+    public updated_at?: FieldValue | Timestamp,
+  ) {
     super(iRenewableAskHistory);
   }
 

--- a/common/src/entities/renewable-bid-histories/renewable-bid-history.ts
+++ b/common/src/entities/renewable-bid-histories/renewable-bid-history.ts
@@ -2,7 +2,12 @@ import { proto } from '../..';
 import { FieldValue, Timestamp } from 'firebase/firestore';
 
 export class RenewableBidHistory extends proto.main.RenewableBidHistory {
-  constructor(iRenewableBidHistory: proto.main.IRenewableBidHistory, public created_at?: FieldValue | Timestamp, public updated_at?: FieldValue | Timestamp) {
+  constructor(
+    iRenewableBidHistory: proto.main.IRenewableBidHistory,
+    public bid_created_at?: FieldValue | Timestamp,
+    public created_at?: FieldValue | Timestamp,
+    public updated_at?: FieldValue | Timestamp,
+  ) {
     super(iRenewableBidHistory);
   }
 

--- a/functions/src/normal-settlements/normal-settlement.ts
+++ b/functions/src/normal-settlements/normal-settlement.ts
@@ -23,27 +23,33 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
     if (sortNormalBids[i].price < data.price || sortNormalAsks[j].price > data.price) {
       for (; i < sortNormalBids.length; i++) {
         await normal_bid_history.create(
-          new NormalBidHistory({
-            account_id: sortNormalBids[i].account_id,
-            price: sortNormalBids[i].price,
-            amount: sortNormalBids[i].amount,
-            is_accepted: false,
-            contract_price: data.price,
-          }),
+          new NormalBidHistory(
+            {
+              account_id: sortNormalBids[i].account_id,
+              price: sortNormalBids[i].price,
+              amount: sortNormalBids[i].amount,
+              is_accepted: false,
+              contract_price: data.price,
+            },
+            sortNormalBids[i].created_at,
+          ),
         );
         await normal_bid.delete_(sortNormalBids[i].id);
       }
 
       for (; j < sortNormalAsks.length; j++) {
         await normal_ask_history.create(
-          new NormalAskHistory({
-            type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
-            account_id: sortNormalAsks[j].account_id,
-            price: sortNormalAsks[j].price,
-            amount: sortNormalAsks[j].amount,
-            is_accepted: false,
-            contract_price: data.price,
-          }),
+          new NormalAskHistory(
+            {
+              type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
+              account_id: sortNormalAsks[j].account_id,
+              price: sortNormalAsks[j].price,
+              amount: sortNormalAsks[j].amount,
+              is_accepted: false,
+              contract_price: data.price,
+            },
+            sortNormalAsks[j].created_at,
+          ),
         );
         await normal_ask.delete_(sortNormalAsks[j].id);
       }
@@ -61,25 +67,31 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
       );
 
       await normal_bid_history.create(
-        new NormalBidHistory({
-          account_id: sortNormalBids[i].account_id,
-          price: sortNormalBids[i].price,
-          amount: sortNormalBids[i].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new NormalBidHistory(
+          {
+            account_id: sortNormalBids[i].account_id,
+            price: sortNormalBids[i].price,
+            amount: sortNormalBids[i].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortNormalBids[i].created_at,
+        ),
       );
       await normal_bid.delete_(sortNormalBids[i].id);
 
       await normal_ask_history.create(
-        new NormalAskHistory({
-          type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
-          account_id: sortNormalAsks[j].account_id,
-          price: sortNormalAsks[j].price,
-          amount: sortNormalBids[i].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new NormalAskHistory(
+          {
+            type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
+            account_id: sortNormalAsks[j].account_id,
+            price: sortNormalAsks[j].price,
+            amount: sortNormalBids[i].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortNormalAsks[j].created_at,
+        ),
       );
       await normal_ask.delete_(sortNormalAsks[j].id);
 
@@ -99,25 +111,31 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
       );
 
       await normal_bid_history.create(
-        new NormalBidHistory({
-          account_id: sortNormalBids[i].account_id,
-          price: sortNormalBids[i].price,
-          amount: sortNormalAsks[j].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new NormalBidHistory(
+          {
+            account_id: sortNormalBids[i].account_id,
+            price: sortNormalBids[i].price,
+            amount: sortNormalAsks[j].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortNormalBids[i].created_at,
+        ),
       );
       await normal_bid.delete_(sortNormalBids[i].id);
 
       await normal_ask_history.create(
-        new NormalAskHistory({
-          type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
-          account_id: sortNormalAsks[j].account_id,
-          price: sortNormalAsks[j].price,
-          amount: sortNormalAsks[j].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new NormalAskHistory(
+          {
+            type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
+            account_id: sortNormalAsks[j].account_id,
+            price: sortNormalAsks[j].price,
+            amount: sortNormalAsks[j].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortNormalAsks[j].created_at,
+        ),
       );
       await normal_ask.delete_(sortNormalAsks[j].id);
 
@@ -137,26 +155,32 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
       );
 
       await normal_bid_history.create(
-        new NormalBidHistory({
-          account_id: sortNormalBids[i].account_id,
-          price: sortNormalBids[i].price,
-          amount: sortNormalBids[i].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new NormalBidHistory(
+          {
+            account_id: sortNormalBids[i].account_id,
+            price: sortNormalBids[i].price,
+            amount: sortNormalBids[i].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortNormalBids[i].created_at,
+        ),
       );
 
       await normal_bid.delete_(sortNormalBids[i].id);
 
       await normal_ask_history.create(
-        new NormalAskHistory({
-          type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
-          account_id: sortNormalAsks[j].account_id,
-          price: sortNormalAsks[j].price,
-          amount: sortNormalBids[i].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new NormalAskHistory(
+          {
+            type: sortNormalAsks[j].type as unknown as proto.main.NormalAskHistoryType,
+            account_id: sortNormalAsks[j].account_id,
+            price: sortNormalAsks[j].price,
+            amount: sortNormalBids[i].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortNormalAsks[j].created_at,
+        ),
       );
       await normal_ask.delete_(sortNormalAsks[j].id);
 

--- a/functions/src/renewable-settlements/renewable-settlement.ts
+++ b/functions/src/renewable-settlements/renewable-settlement.ts
@@ -23,27 +23,33 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
     if (sortRenewableBids[i].price < data.price || sortRenewableAsks[j].price > data.price) {
       for (; i < sortRenewableBids.length; i++) {
         await renewable_bid_history.create(
-          new RenewableBidHistory({
-            account_id: sortRenewableBids[i].account_id,
-            price: sortRenewableBids[i].price,
-            amount: sortRenewableBids[i].amount,
-            is_accepted: false,
-            contract_price: data.price,
-          }),
+          new RenewableBidHistory(
+            {
+              account_id: sortRenewableBids[i].account_id,
+              price: sortRenewableBids[i].price,
+              amount: sortRenewableBids[i].amount,
+              is_accepted: false,
+              contract_price: data.price,
+            },
+            sortRenewableBids[i].created_at,
+          ),
         );
         await renewable_bid.delete_(sortRenewableBids[i].id);
       }
 
       for (; j < sortRenewableAsks.length; j++) {
         await renewable_ask_history.create(
-          new RenewableAskHistory({
-            type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
-            account_id: sortRenewableAsks[j].account_id,
-            price: sortRenewableAsks[j].price,
-            amount: sortRenewableAsks[j].amount,
-            is_accepted: false,
-            contract_price: data.price,
-          }),
+          new RenewableAskHistory(
+            {
+              type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
+              account_id: sortRenewableAsks[j].account_id,
+              price: sortRenewableAsks[j].price,
+              amount: sortRenewableAsks[j].amount,
+              is_accepted: false,
+              contract_price: data.price,
+            },
+            sortRenewableAsks[j].created_at,
+          ),
         );
         await renewable_ask.delete_(sortRenewableAsks[j].id);
       }
@@ -61,25 +67,31 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
       );
 
       await renewable_bid_history.create(
-        new RenewableBidHistory({
-          account_id: sortRenewableBids[i].account_id,
-          price: sortRenewableBids[i].price,
-          amount: sortRenewableBids[i].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new RenewableBidHistory(
+          {
+            account_id: sortRenewableBids[i].account_id,
+            price: sortRenewableBids[i].price,
+            amount: sortRenewableBids[i].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortRenewableBids[i].created_at,
+        ),
       );
       await renewable_bid.delete_(sortRenewableBids[i].id);
 
       await renewable_ask_history.create(
-        new RenewableAskHistory({
-          type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
-          account_id: sortRenewableAsks[j].account_id,
-          price: sortRenewableAsks[j].price,
-          amount: sortRenewableBids[i].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new RenewableAskHistory(
+          {
+            type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
+            account_id: sortRenewableAsks[j].account_id,
+            price: sortRenewableAsks[j].price,
+            amount: sortRenewableBids[i].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortRenewableAsks[j].created_at,
+        ),
       );
       await renewable_ask.delete_(sortRenewableAsks[j].id);
 
@@ -99,25 +111,31 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
       );
 
       await renewable_bid_history.create(
-        new RenewableBidHistory({
-          account_id: sortRenewableBids[i].account_id,
-          price: sortRenewableBids[i].price,
-          amount: sortRenewableAsks[j].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new RenewableBidHistory(
+          {
+            account_id: sortRenewableBids[i].account_id,
+            price: sortRenewableBids[i].price,
+            amount: sortRenewableAsks[j].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortRenewableBids[i].created_at,
+        ),
       );
       await renewable_bid.delete_(sortRenewableBids[i].id);
 
       await renewable_ask_history.create(
-        new RenewableAskHistory({
-          type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
-          account_id: sortRenewableAsks[j].account_id,
-          price: sortRenewableAsks[j].price,
-          amount: sortRenewableAsks[j].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new RenewableAskHistory(
+          {
+            type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
+            account_id: sortRenewableAsks[j].account_id,
+            price: sortRenewableAsks[j].price,
+            amount: sortRenewableAsks[j].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortRenewableAsks[j].created_at,
+        ),
       );
       await renewable_ask.delete_(sortRenewableAsks[j].id);
 
@@ -137,26 +155,32 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
       );
 
       await renewable_bid_history.create(
-        new RenewableBidHistory({
-          account_id: sortRenewableBids[i].account_id,
-          price: sortRenewableBids[i].price,
-          amount: sortRenewableBids[i].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new RenewableBidHistory(
+          {
+            account_id: sortRenewableBids[i].account_id,
+            price: sortRenewableBids[i].price,
+            amount: sortRenewableBids[i].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortRenewableBids[i].created_at,
+        ),
       );
 
       await renewable_bid.delete_(sortRenewableBids[i].id);
 
       await renewable_ask_history.create(
-        new RenewableAskHistory({
-          type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
-          account_id: sortRenewableAsks[j].account_id,
-          price: sortRenewableAsks[j].price,
-          amount: sortRenewableBids[i].amount,
-          is_accepted: true,
-          contract_price: data.price,
-        }),
+        new RenewableAskHistory(
+          {
+            type: sortRenewableAsks[j].type as unknown as proto.main.RenewableAskHistoryType,
+            account_id: sortRenewableAsks[j].account_id,
+            price: sortRenewableAsks[j].price,
+            amount: sortRenewableBids[i].amount,
+            is_accepted: true,
+            contract_price: data.price,
+          },
+          sortRenewableAsks[j].created_at,
+        ),
       );
       await renewable_ask.delete_(sortRenewableAsks[j].id);
 

--- a/functions/src/single-price-normal-settlements/normal-contract.ts
+++ b/functions/src/single-price-normal-settlements/normal-contract.ts
@@ -29,24 +29,30 @@ module.exports.normalContract = f.pubsub
 
       for (const bid of normalBids) {
         await normal_bid_history.create(
-          new NormalBidHistory({
-            account_id: bid.account_id,
-            price: bid.price,
-            amount: bid.amount,
-            is_accepted: false,
-          }),
+          new NormalBidHistory(
+            {
+              account_id: bid.account_id,
+              price: bid.price,
+              amount: bid.amount,
+              is_accepted: false,
+            },
+            bid.created_at,
+          ),
         );
         await normal_bid.delete_(bid.id);
       }
 
       for (const ask of normalAsks) {
         await normal_ask_history.create(
-          new NormalAskHistory({
-            account_id: ask.account_id,
-            price: ask.price,
-            amount: ask.amount,
-            is_accepted: false,
-          }),
+          new NormalAskHistory(
+            {
+              account_id: ask.account_id,
+              price: ask.price,
+              amount: ask.amount,
+              is_accepted: false,
+            },
+            ask.created_at,
+          ),
         );
         await normal_ask.delete_(ask.id);
       }
@@ -71,24 +77,30 @@ module.exports.normalContract = f.pubsub
 
       for (const bid of sortNormalBids) {
         await normal_bid_history.create(
-          new NormalBidHistory({
-            account_id: bid.account_id,
-            price: bid.price,
-            amount: bid.amount,
-            is_accepted: false,
-          }),
+          new NormalBidHistory(
+            {
+              account_id: bid.account_id,
+              price: bid.price,
+              amount: bid.amount,
+              is_accepted: false,
+            },
+            bid.created_at,
+          ),
         );
         await normal_bid.delete_(bid.id);
       }
 
       for (const ask of sortNormalAsks) {
         await normal_ask_history.create(
-          new NormalAskHistory({
-            account_id: ask.account_id,
-            price: ask.price,
-            amount: ask.amount,
-            is_accepted: false,
-          }),
+          new NormalAskHistory(
+            {
+              account_id: ask.account_id,
+              price: ask.price,
+              amount: ask.amount,
+              is_accepted: false,
+            },
+            ask.created_at,
+          ),
         );
         await normal_ask.delete_(ask.id);
       }

--- a/functions/src/single-price-renewable-settlements/renewable-contract.ts
+++ b/functions/src/single-price-renewable-settlements/renewable-contract.ts
@@ -29,24 +29,30 @@ module.exports.renewableContract = f.pubsub
 
       for (const bid of renewableBids) {
         await renewable_bid_history.create(
-          new RenewableBidHistory({
-            account_id: bid.account_id,
-            price: bid.price,
-            amount: bid.amount,
-            is_accepted: false,
-          }),
+          new RenewableBidHistory(
+            {
+              account_id: bid.account_id,
+              price: bid.price,
+              amount: bid.amount,
+              is_accepted: false,
+            },
+            bid.created_at,
+          ),
         );
         await renewable_bid.delete_(bid.id);
       }
 
       for (const ask of renewableAsks) {
         await renewable_ask_history.create(
-          new RenewableAskHistory({
-            account_id: ask.account_id,
-            price: ask.price,
-            amount: ask.amount,
-            is_accepted: false,
-          }),
+          new RenewableAskHistory(
+            {
+              account_id: ask.account_id,
+              price: ask.price,
+              amount: ask.amount,
+              is_accepted: false,
+            },
+            ask.created_at,
+          ),
         );
         await renewable_ask.delete_(ask.id);
       }
@@ -71,24 +77,30 @@ module.exports.renewableContract = f.pubsub
 
       for (const bid of sortRenewableBids) {
         await renewable_bid_history.create(
-          new RenewableBidHistory({
-            account_id: bid.account_id,
-            price: bid.price,
-            amount: bid.amount,
-            is_accepted: false,
-          }),
+          new RenewableBidHistory(
+            {
+              account_id: bid.account_id,
+              price: bid.price,
+              amount: bid.amount,
+              is_accepted: false,
+            },
+            bid.created_at,
+          ),
         );
         await renewable_bid.delete_(bid.id);
       }
 
       for (const ask of sortRenewableAsks) {
         await renewable_ask_history.create(
-          new RenewableAskHistory({
-            account_id: ask.account_id,
-            price: ask.price,
-            amount: ask.amount,
-            is_accepted: false,
-          }),
+          new RenewableAskHistory(
+            {
+              account_id: ask.account_id,
+              price: ask.price,
+              amount: ask.amount,
+              is_accepted: false,
+            },
+            ask.created_at,
+          ),
         );
         await renewable_ask.delete_(ask.id);
       }


### PR DESCRIPTION
@KimuraYu45z common-entityに直接変更を入れてますが、以下の変更で問題ないか確認いただけると助かります。
池田先生より一昨日リクエストがあり、現状のデータベースの仕様では対応できなかったBid, Askの時間推移を出せるようにするための変更です。

1949ce1e0ed2cc81018eb9a8989e29066ec1cfda
protoに`google.protobuf.Timestamp`を追加する方法だとfirebase/firestore/Timestampにならなかったのでentityを変更して、注文の作成時刻を記録できるようにしています。

39da26dc028c07b9925bbfa9a19739ea4d9185f3
Fuction内でHistoryを作成する際に元の注文のデータから作成時刻を記録しています。