### PR TITLE
Dashboard ranking

### DIFF
--- a/projects/main/src/app/page/admin/dashboard/dashboard.component.ts
+++ b/projects/main/src/app/page/admin/dashboard/dashboard.component.ts
@@ -215,7 +215,25 @@ export class DashboardComponent implements OnInit {
           ),
         ),
       ),
-      map((rankings) => rankings.sort((first, second) => second.amount - first.amount)),
+      // projects/main/src/app/page/dashboard/dashboard.component.ts からのコピペ
+      // mapはforEachの機能に加えて新しい配列を返します（forEachは何も返さず、必ずvoidになる）
+      map((rankings) => {
+        let count = 0;
+        let tmp = 0;
+        // ここでランキングをソートして、順位をrankに入れる
+        let sortedRanking = rankings
+          .sort((first, second) => second.amount - first.amount)
+          .map((item, index) => {
+            if (item.amount !== tmp) {
+              count = index + 1;
+              tmp = item.amount;
+            }
+            // ここのreturnは86行目{}を受けてreturnしてます (85行目Array.map()の返り値)
+            return { id: item.id, rank: count, name: item.name, amount: item.amount };
+          });
+        //  ここのreturnは79行目{}を受けてreturnしてます (79行目Observable.map()の返り値)
+        return sortedRanking;
+      }),
     );
     this.normalAsks$ = this.normalAskApp.list$().pipe(map((asks) => asks.filter((ask) => ask.is_deleted != true)));
     this.normalBids$ = this.normalBidApp.list$().pipe(map((bids) => bids.filter((bid) => bid.is_deleted != true)));

--- a/projects/main/src/app/view/admin/dashboard/dashboard.component.html
+++ b/projects/main/src/app/view/admin/dashboard/dashboard.component.html
@@ -126,7 +126,7 @@
     <mat-list>
       <ng-container *ngFor="let ranking of rankings; let i = index">
         <mat-list-item class="flex flex-wrap">
-          <span class="break-all">{{ i + 1 }}</span>
+          <span class="break-all">{{ ranking.rank }}</span>
           <span class="flex-auto break-all"></span>
           <span class="break-all">{{ ranking.name }}</span>
           <span class="flex-auto break-all"></span>


### PR DESCRIPTION
close #244 (余分なコミットが大量に混ざってる)

@KokiKumagai #244 をクローズしてこっちマージする予定です。コメントアウトで各説明書いておいたので確認とレビューお願いします。必要あればまたハドルでも説明します。

# 手順

## 同着順位を考慮したランキングの作り方をググる
出たもの → https://teratail.com/questions/62671
今回はこれを使います。

## これで実装すると`forEach()`の返り値が何をやってもvoidになります。そこでいつものJSの関数を見る。
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
これに従うと`forEach()`が返り値を持たないことがわかります。`console.log()`のように返り値が必要ないもののみ。

## 配列を使って新しい配列を返す方法を調べる（思い出す）と`map()`だと気づく。（他のところでも大量に使ってる）
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/map

`map()`と`forEach()`の違いは返り値の有無です。これは今回で覚えてほしい一番のポイント。
https://tcd-theme.com/2021/07/foreach-map-filter.html

## 以上より、`sort()`したものに対して、ランキングを作り方を使って、rankというフィールドに入れてあげるとOKです。
```
export interface Ranking {
  id: string;
  rank: number;
  name: string;
  amount: number;
}
```
`rank: number;`を追記します。
で、`Observable.map()`の返り値を今回変更した形に合わせてあげるとOKです。

ここまでが ccee5a9f39a1a76093d551933cab6150a9565923

## これだとコンパイルエラーが発生します。なぜなら、admin/dashboardでもRanking型を使っていたためです。
なので、今回はadmin/dashboardもコピペで同じ形で返すようにします。
この変更が 8b7e4a434710722a2685424bf49f88e3fd7df495

変更完了を`ng serve`して確認
![スクリーンショット 2022-03-15 124420](https://user-images.githubusercontent.com/29295263/158305148-bef99dde-2710-4b08-a750-12af8e7f1283.png)

