### PR TITLE
注文のダウンタイムに関するフロント実装

### DIFF
--- a/projects/main/src/app/page/accounts/account/account.component.ts
+++ b/projects/main/src/app/page/accounts/account/account.component.ts
@@ -34,8 +34,8 @@ export class AccountComponent implements OnInit {
     private readonly monthlyPaymentApp: MonthlyPaymentApplicationService,
   ) {
     let firstDay = new Date();
-    firstDay.setDate(1);
-    firstDay.setHours(0, 0, 0, 0);
+    firstDay.setUTCDate(1);
+    firstDay.setUTCHours(0, 0, 0, 0);
     this.user$ = authState(this.auth);
     this.studentAccount$ = this.user$.pipe(mergeMap((user) => this.studentAccApp.getByUid$(user?.uid!)));
     this.balances$ = this.studentAccount$.pipe(mergeMap((account) => (!account ? of(null) : this.balanceApp.getByUid$(account.id))));

--- a/projects/main/src/app/page/admin/dashboard/dashboard.component.ts
+++ b/projects/main/src/app/page/admin/dashboard/dashboard.component.ts
@@ -106,8 +106,8 @@ export class DashboardComponent implements OnInit {
   ) {
     const now = new Date();
     let firstDay = new Date();
-    firstDay.setDate(1);
-    firstDay.setHours(0, 0, 0, 0);
+    firstDay.setUTCDate(1);
+    firstDay.setUTCHours(0, 0, 0, 0);
     const users$ = this.studentsApp.list$();
 
     this.balances$ = users$.pipe(

--- a/projects/main/src/app/page/dashboard/dashboard.component.ts
+++ b/projects/main/src/app/page/dashboard/dashboard.component.ts
@@ -90,8 +90,8 @@ export class DashboardComponent implements OnInit {
   ) {
     const now = new Date();
     let firstDay = new Date();
-    firstDay.setDate(1);
-    firstDay.setHours(0, 0, 0, 0);
+    firstDay.setUTCDate(1);
+    firstDay.setUTCHours(0, 0, 0, 0);
     const currentUser$ = authState(this.auth);
     const studentAccount$ = currentUser$.pipe(mergeMap((user) => this.studentAccApp.getByUid$(user?.uid!)));
     const users$ = this.studentsApp.list$();

--- a/projects/main/src/app/page/txs/buy/buy.component.ts
+++ b/projects/main/src/app/page/txs/buy/buy.component.ts
@@ -44,8 +44,8 @@ export class BuyComponent implements OnInit {
     this.price = 27;
     this.amount = 1;
     let firstDay = new Date();
-    firstDay.setDate(1);
-    firstDay.setHours(0, 0, 0, 0);
+    firstDay.setUTCDate(1);
+    firstDay.setUTCHours(0, 0, 0, 0);
     const user$ = authState(this.auth);
     this.studentAccount$ = user$.pipe(mergeMap((user) => this.studentAccApp.getByUid$(user?.uid!)));
     const balance$ = this.studentAccount$.pipe(mergeMap((account) => this.availableBalanceApp.list$(account.id)));

--- a/projects/main/src/app/page/txs/sell/sell.component.ts
+++ b/projects/main/src/app/page/txs/sell/sell.component.ts
@@ -44,8 +44,8 @@ export class SellComponent implements OnInit {
     this.price = 27;
     this.amount = 1;
     let firstDay = new Date();
-    firstDay.setDate(1);
-    firstDay.setHours(0, 0, 0, 0);
+    firstDay.setUTCDate(1);
+    firstDay.setUTCHours(0, 0, 0, 0);
     const user$ = authState(this.auth);
     this.studentAccount$ = user$.pipe(mergeMap((user) => this.studentAccApp.getByUid$(user?.uid!)));
     const balance$ = this.studentAccount$.pipe(mergeMap((account) => this.availableBalanceApp.list$(account.id)));

--- a/projects/main/src/app/page/txs/txs.component.ts
+++ b/projects/main/src/app/page/txs/txs.component.ts
@@ -69,8 +69,8 @@ export class TxsComponent implements OnInit {
     const renewableAsks$ = this.studentAccount$.pipe(mergeMap((account) => this.renewableAskApp.listUid$(account.id)));
     const now = new Date();
     let firstDay = new Date();
-    firstDay.setDate(1);
-    firstDay.setHours(0, 0, 0, 0);
+    firstDay.setUTCDate(1);
+    firstDay.setUTCHours(0, 0, 0, 0);
 
     this.orders$ = combineLatest([normalBids$, normalAsks$, renewableBids$, renewableAsks$]).pipe(
       map(([normalBids, normalAsks, renewableBids, renewableAsks]) => {

--- a/projects/main/src/app/view/txs/buy/buy.component.html
+++ b/projects/main/src/app/view/txs/buy/buy.component.html
@@ -100,12 +100,15 @@
         <mat-card-content>
           <p>Create a Bid request for the day's single-price auction.</p>
           <p>
-            At 0:00 every day, the market will set the intersection of the sell curve and the buy curve as the contract price and contract
-            quantity.
+            At 9:00 (JST) every day, the market will set the intersection of the sell curve and the buy curve as the contract price and
+            contract quantity.
           </p>
         </mat-card-content>
       </details>
-      <mat-card-content class="mt-5">the average price of electricity for end users is approximately <b>&yen;27/kWh</b>.</mat-card-content>
+      <mat-card-content class="mt-5">
+        <p>The average price of electricity for end users is approximately <b>&yen;27/kWh</b>.</p>
+        <p>You cannot order between 9:00-12:00 (JST).</p>
+      </mat-card-content>
       <mat-list>
         <h3 matSubheader>Token Price</h3>
         <mat-list-item class="flex flex-wrap">

--- a/projects/main/src/app/view/txs/buy/buy.component.ts
+++ b/projects/main/src/app/view/txs/buy/buy.component.ts
@@ -55,6 +55,11 @@ export class BuyComponent implements OnInit {
   ngOnInit(): void {}
 
   onSubmit(accountID: string, price: string, amount: string, denom: string) {
+    const now = new Date();
+    if (0 < now.getUTCHours() && now.getUTCHours() < 3) {
+      alert('EDISONでは、9:00-12:00(JST)のAskの入札ができません');
+      return;
+    }
     if (!denom) {
       alert('トークンの種類を指定してください。\nUPX=電力会社、SPX=太陽光発電');
       return;

--- a/projects/main/src/app/view/txs/sell/sell.component.html
+++ b/projects/main/src/app/view/txs/sell/sell.component.html
@@ -100,12 +100,15 @@
         <mat-card-content>
           <p>Create a Ask request for the day's single-price auction.</p>
           <p>
-            At 0:00 every day, the market will set the intersection of the sell curve and the buy curve as the contract price and contract
-            quantity.
+            At 9:00 (JST) every day, the market will set the intersection of the sell curve and the buy curve as the contract price and
+            contract quantity.
           </p>
         </mat-card-content>
       </details>
-      <mat-card-content class="mt-5">the average price of electricity for end users is approximately <b>&yen;27/kWh</b>.</mat-card-content>
+      <mat-card-content class="mt-5">
+        <p>The average price of electricity for end users is approximately <b>&yen;27/kWh</b>.</p>
+        <p>You cannot order between 9:00-12:00 (JST).</p>
+      </mat-card-content>
       <mat-list>
         <h3 matSubheader>Token Price</h3>
         <mat-list-item class="flex flex-wrap">

--- a/projects/main/src/app/view/txs/sell/sell.component.ts
+++ b/projects/main/src/app/view/txs/sell/sell.component.ts
@@ -56,8 +56,8 @@ export class SellComponent implements OnInit {
 
   onSubmit(accountID: string, price: string, amount: string, denom: string) {
     const now = new Date();
-    if (0 < now.getHours() && now.getHours() < 11) {
-      alert('現在、EDISONでは、0-11時のAskの入札ができません');
+    if (0 < now.getUTCHours() && now.getUTCHours() < 3) {
+      alert('EDISONでは、9:00-12:00(JST)のAskの入札ができません');
       return;
     }
     if (!denom) {


### PR DESCRIPTION
#218を参照
https://github.com/KyotoUniv-SIC/electoric-power-exchange/pull/268/commits/d5f9a0d3abd1e3049c8ab8edcdccf24e3a03490b
注文の発行にダウンタイムを設けた

https://github.com/KyotoUniv-SIC/electoric-power-exchange/pull/268/commits/54be619074552a4fa1270f08fae40cea2a8f1a8a
フロントで日付指定で取得している箇所をタイムゾーンに依存しないよう、UTCに変更