### PR TITLE
ゼロ成約での処理改善

### DIFF
--- a/functions/src/daily-payments/create-balance.ts
+++ b/functions/src/daily-payments/create-balance.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 /* eslint-disable camelcase */
-import { daily_payment } from '.';
+// import { daily_payment } from '.';
 import { account_private } from '../account-privates';
 import { admin_account } from '../admin-accounts';
 import { balance } from '../balances';
@@ -9,7 +9,8 @@ import { insufficient_balance } from '../insufficient-balances';
 import { InsufficientBalance, DailyPayment, Balance } from '@local/common';
 import * as crypto from 'crypto-js';
 
-daily_payment.onCreateHandler.push(async (snapshot, context) => {
+// daily_payment.onCreateHandler.push()
+export const dailyPaymentOnCreate = async (snapshot: any, context: any) => {
   const data = snapshot.data()! as DailyPayment;
   const accountBalance = await balance.listLatest(data.student_account_id);
   await balance.create(
@@ -97,4 +98,4 @@ daily_payment.onCreateHandler.push(async (snapshot, context) => {
     }
     client.disconnect();
   }
-});
+};

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -26,6 +26,7 @@ import * as admin from 'firebase-admin';
 // import * as functions from 'firebase-functions';
 
 admin.initializeApp();
+admin.firestore().settings({ ignoreUndefinedProperties: true });
 // admin.initializeApp({
 //   credential: admin.credential.cert(JSON.parse(JSON.stringify(functions.config().service_account).replace(/\\\\n/g, '\\n'))),
 //   databaseURL: functions.config().admin.database_url,

--- a/functions/src/normal-settlements/create-balance.ts
+++ b/functions/src/normal-settlements/create-balance.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 /* eslint-disable camelcase */
-import { normal_settlement } from '.';
+// import { normal_settlement } from '.';
 import { account_private } from '../account-privates';
 import { admin_account } from '../admin-accounts';
 import { admin_private } from '../admin-privates';
@@ -10,7 +10,8 @@ import { student_account } from '../student-accounts';
 import { Balance, NormalSettlement } from '@local/common';
 import * as crypto from 'crypto-js';
 
-normal_settlement.onCreateHandler.push(async (snapshot, context) => {
+// normal_settlement.onCreateHandler.push()
+export const normalSettlementOnCreate = async (snapshot: any, context: any) => {
   const data = snapshot.data()! as NormalSettlement;
   const bidderBalance = await balance.listLatest(data.bid_id);
   await balance.create(
@@ -116,4 +117,4 @@ normal_settlement.onCreateHandler.push(async (snapshot, context) => {
     }
     client.disconnect();
   }
-});
+};

--- a/functions/src/renewable-settlements/create-balance.ts
+++ b/functions/src/renewable-settlements/create-balance.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 /* eslint-disable camelcase */
-import { renewable_settlement } from '.';
+// import { renewable_settlement } from '.';
 import { account_private } from '../account-privates';
 import { admin_account } from '../admin-accounts';
 import { admin_private } from '../admin-privates';
@@ -10,7 +10,8 @@ import { student_account } from '../student-accounts';
 import { Balance, RenewableSettlement } from '@local/common';
 import * as crypto from 'crypto-js';
 
-renewable_settlement.onCreateHandler.push(async (snapshot, context) => {
+// renewable_settlement.onCreateHandler.push()
+export const renewableSettlementOnCreate = async (snapshot: any, context: any) => {
   const data = snapshot.data()! as RenewableSettlement;
   const bidderBalance = await balance.listLatest(data.bid_id);
   await balance.create(
@@ -117,4 +118,4 @@ renewable_settlement.onCreateHandler.push(async (snapshot, context) => {
     }
     client.disconnect();
   }
-});
+};

--- a/functions/src/schedules/contract-normal.ts
+++ b/functions/src/schedules/contract-normal.ts
@@ -19,6 +19,13 @@ module.exports.contractNormal = f.pubsub
     if (!normalBids.length || !normalAsks.length) {
       console.log('bid,askの不足でUPX成約は0です。');
 
+      await single_price_normal_settlement.create(
+        new SinglePriceNormalSettlement({
+          price_ujpy: '0',
+          amount_uupx: '0',
+        }),
+      );
+
       await Promise.all(
         normalBids.map(async (bid) => {
           await normal_bid_history.create(
@@ -65,6 +72,13 @@ module.exports.contractNormal = f.pubsub
     // 最高値のBidが最安値のAskより低い場合0成約で終了
     if (parseInt(sortNormalBids[0].price_ujpy) < parseInt(sortNormalAsks[0].price_ujpy)) {
       console.log('UPX成約はありませんでした。');
+
+      await single_price_normal_settlement.create(
+        new SinglePriceNormalSettlement({
+          price_ujpy: '0',
+          amount_uupx: '0',
+        }),
+      );
 
       await Promise.all(
         sortNormalBids.map(async (bid) => {

--- a/functions/src/schedules/contract-renewable.ts
+++ b/functions/src/schedules/contract-renewable.ts
@@ -19,6 +19,13 @@ module.exports.contractRenewable = f.pubsub
     if (!renewableBids.length || !renewableAsks.length) {
       console.log('bid,askの不足でSPX成約は0です。');
 
+      await single_price_renewable_settlement.create(
+        new SinglePriceRenewableSettlement({
+          price_ujpy: '0',
+          amount_uspx: '0',
+        }),
+      );
+
       await Promise.all(
         renewableBids.map(async (bid) => {
           await renewable_bid_history.create(
@@ -65,6 +72,13 @@ module.exports.contractRenewable = f.pubsub
     // i,j両方が0のとき、成約は0になる
     if (parseInt(sortRenewableBids[0].price_ujpy) < parseInt(sortRenewableAsks[0].price_ujpy)) {
       console.log('SPX成約はありませんでした。');
+
+      await single_price_renewable_settlement.create(
+        new SinglePriceRenewableSettlement({
+          price_ujpy: '0',
+          amount_uspx: '0',
+        }),
+      );
 
       await Promise.all(
         sortRenewableBids.map(async (bid) => {

--- a/functions/src/schedules/daily-withdraw.ts
+++ b/functions/src/schedules/daily-withdraw.ts
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import { balance } from '../balances';
 import { daily_payment } from '../daily-payments';
+import { dailyPaymentOnCreate } from '../daily-payments/create-balance';
 import { daily_usage } from '../daily-usages';
 import { student_account } from '../student-accounts';
 import { DailyPayment } from '@local/common';
@@ -50,18 +51,18 @@ module.exports.dailyWithdraw = f.pubsub
 
           const now = new Date();
 
-          await daily_payment.create(
-            new DailyPayment({
-              student_account_id: student.id,
-              year: now.getFullYear().toString(),
-              month: (now.getMonth() + 1).toString(),
-              date: now.getDate().toString(),
-              amount_mwh: usage.toString(),
-              amount_uupx: uupxPayment,
-              amount_uspx: uspxPayment,
-              amount_insufficiency: insufficiency,
-            }),
-          );
+          const dailyPayment = new DailyPayment({
+            student_account_id: student.id,
+            year: now.getFullYear().toString(),
+            month: (now.getMonth() + 1).toString(),
+            date: now.getDate().toString(),
+            amount_mwh: usage.toString(),
+            amount_uupx: uupxPayment,
+            amount_uspx: uspxPayment,
+            amount_insufficiency: insufficiency,
+          });
+          await daily_payment.create(dailyPayment);
+          await dailyPaymentOnCreate({ data: () => dailyPayment }, null);
         }
       }
     }

--- a/functions/src/schedules/daily-withdraw.ts
+++ b/functions/src/schedules/daily-withdraw.ts
@@ -50,7 +50,6 @@ module.exports.dailyWithdraw = f.pubsub
           }
 
           const now = new Date();
-
           const dailyPayment = new DailyPayment({
             student_account_id: student.id,
             year: now.getFullYear().toString(),
@@ -61,6 +60,7 @@ module.exports.dailyWithdraw = f.pubsub
             amount_uspx: uspxPayment,
             amount_insufficiency: insufficiency,
           });
+
           await daily_payment.create(dailyPayment);
           await dailyPaymentOnCreate({ data: () => dailyPayment }, null);
         }

--- a/functions/src/single-price-normal-settlements/create-normal-settlement.ts
+++ b/functions/src/single-price-normal-settlements/create-normal-settlement.ts
@@ -5,6 +5,7 @@ import { normal_ask } from '../normal-asks';
 import { normal_bid_history } from '../normal-bid-histories';
 import { normal_bid } from '../normal-bids';
 import { normal_settlement } from '../normal-settlements';
+import { normalSettlementOnCreate } from '../normal-settlements/create-balance';
 import { NormalAskHistory, NormalBidHistory, NormalSettlement, proto, SinglePriceNormalSettlement } from '@local/common';
 
 single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) => {
@@ -67,14 +68,13 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
     }
 
     if (parseInt(sortNormalBids[i].amount_uupx) < parseInt(sortNormalAsks[j].amount_uupx)) {
-      await normal_settlement.create(
-        new NormalSettlement({
-          bid_id: sortNormalBids[i].account_id,
-          ask_id: sortNormalAsks[j].account_id,
-          price_ujpy: data.price_ujpy,
-          amount_uupx: sortNormalBids[i].amount_uupx,
-        }),
-      );
+      const normalSettlement = new NormalSettlement({
+        bid_id: sortNormalBids[i].account_id,
+        ask_id: sortNormalAsks[j].account_id,
+        price_ujpy: data.price_ujpy,
+        amount_uupx: sortNormalBids[i].amount_uupx,
+      });
+      await normal_settlement.create(normalSettlement);
 
       await normal_bid_history.create(
         new NormalBidHistory(
@@ -104,6 +104,8 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
         ),
       );
       await normal_ask.delete_(sortNormalAsks[j].id);
+
+      await normalSettlementOnCreate({ data: () => normalSettlement }, null);
 
       sortNormalAsks[j].amount_uupx = (parseInt(sortNormalAsks[j].amount_uupx) - parseInt(sortNormalBids[i].amount_uupx)).toString();
       i++;
@@ -128,14 +130,13 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
         break;
       }
     } else if (parseInt(sortNormalBids[i].amount_uupx) > parseInt(sortNormalAsks[j].amount_uupx)) {
-      await normal_settlement.create(
-        new NormalSettlement({
-          bid_id: sortNormalBids[i].account_id,
-          ask_id: sortNormalAsks[j].account_id,
-          price_ujpy: data.price_ujpy,
-          amount_uupx: sortNormalAsks[j].amount_uupx,
-        }),
-      );
+      const normalSettlement = new NormalSettlement({
+        bid_id: sortNormalBids[i].account_id,
+        ask_id: sortNormalAsks[j].account_id,
+        price_ujpy: data.price_ujpy,
+        amount_uupx: sortNormalAsks[j].amount_uupx,
+      });
+      await normal_settlement.create(normalSettlement);
 
       await normal_bid_history.create(
         new NormalBidHistory(
@@ -165,6 +166,8 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
         ),
       );
       await normal_ask.delete_(sortNormalAsks[j].id);
+
+      await normalSettlementOnCreate({ data: () => normalSettlement }, null);
 
       sortNormalBids[i].amount_uupx = (parseInt(sortNormalBids[i].amount_uupx) - parseInt(sortNormalAsks[j].amount_uupx)).toString();
       j++;
@@ -188,14 +191,13 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
         break;
       }
     } else {
-      await normal_settlement.create(
-        new NormalSettlement({
-          bid_id: sortNormalBids[i].account_id,
-          ask_id: sortNormalAsks[j].account_id,
-          price_ujpy: data.price_ujpy,
-          amount_uupx: sortNormalBids[i].amount_uupx,
-        }),
-      );
+      const normalSettlement = new NormalSettlement({
+        bid_id: sortNormalBids[i].account_id,
+        ask_id: sortNormalAsks[j].account_id,
+        price_ujpy: data.price_ujpy,
+        amount_uupx: sortNormalBids[i].amount_uupx,
+      });
+      await normal_settlement.create(normalSettlement);
 
       await normal_bid_history.create(
         new NormalBidHistory(
@@ -226,6 +228,8 @@ single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) =>
         ),
       );
       await normal_ask.delete_(sortNormalAsks[j].id);
+
+      await normalSettlementOnCreate({ data: () => normalSettlement }, null);
 
       i++;
       j++;

--- a/functions/src/single-price-normal-settlements/create-normal-settlement.ts
+++ b/functions/src/single-price-normal-settlements/create-normal-settlement.ts
@@ -9,6 +9,10 @@ import { NormalAskHistory, NormalBidHistory, NormalSettlement, proto, SinglePric
 
 single_price_normal_settlement.onCreateHandler.push(async (snapshot, context) => {
   const data = snapshot.data()! as SinglePriceNormalSettlement;
+  if (data.amount_uupx == '0') {
+    console.log('no normal contract');
+    return;
+  }
 
   const normalBids = await normal_bid.listValid();
   // 降順

--- a/functions/src/single-price-renewable-settlements/create-renewable-settlement.ts
+++ b/functions/src/single-price-renewable-settlements/create-renewable-settlement.ts
@@ -9,6 +9,10 @@ import { proto, RenewableAskHistory, RenewableBidHistory, RenewableSettlement } 
 
 single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context) => {
   const data = snapshot.data()! as RenewableSettlement;
+  if (data.amount_uspx == '0') {
+    console.log('no renewable contract');
+    return;
+  }
 
   const renewableBids = await renewable_bid.listValid();
   const sortRenewableBids = renewableBids.sort((first, second) => parseInt(second.price_ujpy) - parseInt(first.price_ujpy));

--- a/functions/src/single-price-renewable-settlements/create-renewable-settlement.ts
+++ b/functions/src/single-price-renewable-settlements/create-renewable-settlement.ts
@@ -5,6 +5,7 @@ import { renewable_ask } from '../renewable-asks';
 import { renewable_bid_history } from '../renewable-bid-histories';
 import { renewable_bid } from '../renewable-bids';
 import { renewable_settlement } from '../renewable-settlements';
+import { renewableSettlementOnCreate } from '../renewable-settlements/create-balance';
 import { proto, RenewableAskHistory, RenewableBidHistory, RenewableSettlement } from '@local/common';
 
 single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context) => {
@@ -64,14 +65,13 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
     }
 
     if (parseInt(sortRenewableBids[i].amount_uspx) < parseInt(sortRenewableAsks[j].amount_uspx)) {
-      await renewable_settlement.create(
-        new RenewableSettlement({
-          bid_id: sortRenewableBids[i].account_id,
-          ask_id: sortRenewableAsks[j].account_id,
-          price_ujpy: data.price_ujpy,
-          amount_uspx: sortRenewableBids[i].amount_uspx,
-        }),
-      );
+      const renewableSettlement = new RenewableSettlement({
+        bid_id: sortRenewableBids[i].account_id,
+        ask_id: sortRenewableAsks[j].account_id,
+        price_ujpy: data.price_ujpy,
+        amount_uspx: sortRenewableBids[i].amount_uspx,
+      });
+      await renewable_settlement.create(renewableSettlement);
 
       await renewable_bid_history.create(
         new RenewableBidHistory(
@@ -101,6 +101,8 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
         ),
       );
       await renewable_ask.delete_(sortRenewableAsks[j].id);
+
+      await renewableSettlementOnCreate({ data: () => renewableSettlement }, null);
 
       sortRenewableAsks[j].amount_uspx = (
         parseInt(sortRenewableAsks[j].amount_uspx) - parseInt(sortRenewableBids[i].amount_uspx)
@@ -126,14 +128,13 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
         break;
       }
     } else if (parseInt(sortRenewableBids[i].amount_uspx) > parseInt(sortRenewableAsks[j].amount_uspx)) {
-      await renewable_settlement.create(
-        new RenewableSettlement({
-          bid_id: sortRenewableBids[i].account_id,
-          ask_id: sortRenewableAsks[j].account_id,
-          price_ujpy: data.price_ujpy,
-          amount_uspx: sortRenewableAsks[j].amount_uspx,
-        }),
-      );
+      const renewableSettlement = new RenewableSettlement({
+        bid_id: sortRenewableBids[i].account_id,
+        ask_id: sortRenewableAsks[j].account_id,
+        price_ujpy: data.price_ujpy,
+        amount_uspx: sortRenewableAsks[j].amount_uspx,
+      });
+      await renewable_settlement.create(renewableSettlement);
 
       await renewable_bid_history.create(
         new RenewableBidHistory(
@@ -163,6 +164,8 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
         ),
       );
       await renewable_ask.delete_(sortRenewableAsks[j].id);
+
+      await renewableSettlementOnCreate({ data: () => renewableSettlement }, null);
 
       sortRenewableBids[i].amount_uspx = (
         parseInt(sortRenewableBids[i].amount_uspx) - parseInt(sortRenewableAsks[j].amount_uspx)
@@ -187,14 +190,13 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
         break;
       }
     } else {
-      await renewable_settlement.create(
-        new RenewableSettlement({
-          bid_id: sortRenewableBids[i].account_id,
-          ask_id: sortRenewableAsks[j].account_id,
-          price_ujpy: data.price_ujpy,
-          amount_uspx: sortRenewableBids[i].amount_uspx,
-        }),
-      );
+      const renewableSettlement = new RenewableSettlement({
+        bid_id: sortRenewableBids[i].account_id,
+        ask_id: sortRenewableAsks[j].account_id,
+        price_ujpy: data.price_ujpy,
+        amount_uspx: sortRenewableBids[i].amount_uspx,
+      });
+      await renewable_settlement.create(renewableSettlement);
 
       await renewable_bid_history.create(
         new RenewableBidHistory(
@@ -225,6 +227,8 @@ single_price_renewable_settlement.onCreateHandler.push(async (snapshot, context)
         ),
       );
       await renewable_ask.delete_(sortRenewableAsks[j].id);
+
+      await renewableSettlementOnCreate({ data: () => renewableSettlement }, null);
 
       i++;
       j++;

--- a/functions/src/student-accounts/tx.spec.ts
+++ b/functions/src/student-accounts/tx.spec.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 jest.setTimeout(30000);
-describe('XRPL Create Wallet Test', () => {
+describe('XRPL Send Tx', () => {
   it('create wallet', async () => {
     // const xrpl = require('xrpl');
     // async function sendTx() {
@@ -11,31 +11,44 @@ describe('XRPL Create Wallet Test', () => {
     //   const client = new xrpl.Client(TEST_NET);
     //   await client.connect();
 
-    //   const account = 'rKNFWAUHTww6aPifng1Q8mgpU67KyRNncw';
-    //   const studentSeed = 'U2FsdGVkX1/PfDlNC1wQfF9WuB1GfMgmUaSBwEnMrSu9xfeCEhrIBusUzKmYLy+p';
-    //   const hot = 'rh6hsXVqEjJEFjmEniNur57QXxcYhozSA1';
-    //   const cold = 'rQK41zJnYwZet2ffHrGnVuuYE5rD6pGAhU';
+    //   // studentの情報を入力
+    //   const account = '';
+    //   const studentSeed = '';
 
+    //   // hotアドレスのSeed(decrypted)を入力
+    //   const adminHotSeed = '';
+    //   const adminHot = 'rh6hsXVqEjJEFjmEniNur57QXxcYhozSA1';
+    //   const AdminCold = 'rQK41zJnYwZet2ffHrGnVuuYE5rD6pGAhU';
+
+    //   // 全体の秘密鍵を入力
     //   const privKey = '';
+
+    //   if (!account || !studentSeed || !adminHotSeed || !privKey) {
+    //     console.log('Failed to send tx');
+    //     expect(true).toBeTruthy;
+    //     return;
+    //   }
 
     //   const decryptedSeedStudent = crypto.AES.decrypt(studentSeed, privKey).toString(crypto.enc.Utf8);
 
-    //   // const decryptedSeedAdmin = crypto.AES.decrypt(hotSeed, privKey).toString(crypto.enc.Utf8);
+    //   const decryptedSeedAdmin = crypto.AES.decrypt(adminHotSeed, privKey).toString(crypto.enc.Utf8);
     //   const student = xrpl.Wallet.fromSeed(decryptedSeedStudent);
-    //   // const admin = xrpl.Wallet.fromSeed(decryptedSeedAdmin);
+    //   console.log('student', student);
+    //   const admin = xrpl.Wallet.fromSeed(decryptedSeedAdmin);
+    //   console.log('admin', admin);
 
     //   const sendTokenTx = {
     //     TransactionType: 'Payment',
-    //     Account: account,
+    //     Account: adminHot,
     //     Amount: {
     //       currency: 'UPX',
-    //       value: '5000000',
-    //       issuer: cold,
+    //       value: '104',
+    //       issuer: AdminCold,
     //     },
-    //     Destination: hot,
+    //     Destination: account,
     //   };
     //   const payPrepared = await client.autofill(sendTokenTx);
-    //   const paySigned = student.sign(payPrepared);
+    //   const paySigned = admin.sign(payPrepared);
     //   const payResult = await client.submitAndWait(paySigned.tx_blob);
     //   if (payResult.result.meta.TransactionResult == 'tesSUCCESS') {
     //     console.log(`Transaction succeeded: https://testnet.xrpl.org/transactions/${paySigned.hash}`);
@@ -45,8 +58,7 @@ describe('XRPL Create Wallet Test', () => {
     //   }
     //   client.disconnect();
     // }
-    // const tx = await sendTx();
-    // console.log(tx);
+    // await sendTx();
 
     expect(true).toBeTruthy;
   });

--- a/projects/shared/src/lib/services/single-price-normal-settlements/single-price-normal-settlement.application.service.ts
+++ b/projects/shared/src/lib/services/single-price-normal-settlements/single-price-normal-settlement.application.service.ts
@@ -14,15 +14,17 @@ export class SinglePriceNormalSettlementApplicationService {
     return this.singlePriceNormalSettlement.list$().pipe(
       map(
         (params) =>
-          params.sort(function (first, second) {
-            if ((first.created_at as Timestamp).toDate() < (second.created_at as Timestamp).toDate()) {
-              return 1;
-            } else if ((first.created_at as Timestamp).toDate() > (second.created_at as Timestamp).toDate()) {
-              return -1;
-            } else {
-              return 0;
-            }
-          })[0],
+          params
+            .sort(function (first, second) {
+              if ((first.created_at as Timestamp).toDate() < (second.created_at as Timestamp).toDate()) {
+                return 1;
+              } else if ((first.created_at as Timestamp).toDate() > (second.created_at as Timestamp).toDate()) {
+                return -1;
+              } else {
+                return 0;
+              }
+            })
+            .find((params) => params.amount_uupx != '0')!,
       ),
     );
   }
@@ -31,6 +33,10 @@ export class SinglePriceNormalSettlementApplicationService {
   }
 
   listLatestMonth$() {
+    const first = new Date();
+    first.setMonth(first.getMonth() - 1);
+    first.setDate(1);
+    first.setHours(0, 0, 0, 0);
     const settlements = this.list$().pipe(
       map((params) =>
         params
@@ -43,7 +49,7 @@ export class SinglePriceNormalSettlementApplicationService {
               return 0;
             }
           })
-          .slice(0, 30)
+          .filter((params) => (params.created_at as Timestamp).toDate() > first)
           .reverse(),
       ),
     );

--- a/projects/shared/src/lib/services/single-price-normal-settlements/single-price-normal-settlement.application.service.ts
+++ b/projects/shared/src/lib/services/single-price-normal-settlements/single-price-normal-settlement.application.service.ts
@@ -33,10 +33,6 @@ export class SinglePriceNormalSettlementApplicationService {
   }
 
   listLatestMonth$() {
-    const first = new Date();
-    first.setMonth(first.getMonth() - 1);
-    first.setDate(1);
-    first.setHours(0, 0, 0, 0);
     const settlements = this.list$().pipe(
       map((params) =>
         params
@@ -49,7 +45,7 @@ export class SinglePriceNormalSettlementApplicationService {
               return 0;
             }
           })
-          .filter((params) => (params.created_at as Timestamp).toDate() > first)
+          .slice(0, 7)
           .reverse(),
       ),
     );

--- a/projects/shared/src/lib/services/single-price-renewable-settlements/single-price-renewable-settlement.application.service.ts
+++ b/projects/shared/src/lib/services/single-price-renewable-settlements/single-price-renewable-settlement.application.service.ts
@@ -14,15 +14,17 @@ export class SinglePriceRenewableSettlementApplicationService {
     return this.singlePriceRenewableSettlement.list$().pipe(
       map(
         (params) =>
-          params.sort(function (first, second) {
-            if ((first.created_at as Timestamp).toDate() < (second.created_at as Timestamp).toDate()) {
-              return 1;
-            } else if ((first.created_at as Timestamp).toDate() > (second.created_at as Timestamp).toDate()) {
-              return -1;
-            } else {
-              return 0;
-            }
-          })[0],
+          params
+            .sort(function (first, second) {
+              if ((first.created_at as Timestamp).toDate() < (second.created_at as Timestamp).toDate()) {
+                return 1;
+              } else if ((first.created_at as Timestamp).toDate() > (second.created_at as Timestamp).toDate()) {
+                return -1;
+              } else {
+                return 0;
+              }
+            })
+            .find((params) => params.amount_uspx != '0')!,
       ),
     );
   }
@@ -31,6 +33,10 @@ export class SinglePriceRenewableSettlementApplicationService {
   }
 
   listLatestMonth$() {
+    const first = new Date();
+    first.setMonth(first.getMonth() - 1);
+    first.setDate(1);
+    first.setHours(0, 0, 0, 0);
     return this.list$().pipe(
       map((params) =>
         params
@@ -43,7 +49,7 @@ export class SinglePriceRenewableSettlementApplicationService {
               return 0;
             }
           })
-          .slice(0, 30)
+          .filter((params) => (params.created_at as Timestamp).toDate() > first)
           .reverse(),
       ),
     );

--- a/projects/shared/src/lib/services/single-price-renewable-settlements/single-price-renewable-settlement.application.service.ts
+++ b/projects/shared/src/lib/services/single-price-renewable-settlements/single-price-renewable-settlement.application.service.ts
@@ -33,10 +33,6 @@ export class SinglePriceRenewableSettlementApplicationService {
   }
 
   listLatestMonth$() {
-    const first = new Date();
-    first.setMonth(first.getMonth() - 1);
-    first.setDate(1);
-    first.setHours(0, 0, 0, 0);
     return this.list$().pipe(
       map((params) =>
         params
@@ -49,7 +45,7 @@ export class SinglePriceRenewableSettlementApplicationService {
               return 0;
             }
           })
-          .filter((params) => (params.created_at as Timestamp).toDate() > first)
+          .slice(0, 7)
           .reverse(),
       ),
     );


### PR DESCRIPTION
close #295
same as #298

約定取引が無い場合にこれまではSingle-price-xxxx-settlementが作成されなかったが，作成されるように変更
これにより取引がなかったことがわかりやすくなる。

また，フロントエンドでは0成約を最新の取引として表示しないように変更