### PR TITLE
[WIP] XRPLにTxを送信する箇所の修正

### DIFF
--- a/common/proto/daily_payment_txs/daily_payment_tx.proto
+++ b/common/proto/daily_payment_txs/daily_payment_tx.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+package main;
+
+import "firebase_rules_options.proto";
+
+option (google.firebase.rules.firebase_rules).full_package_names = true;
+
+message DailyPaymentTx {
+  string id = 1;
+  repeated payment txs = 2;
+}
+
+message payment{
+  string student_account_id = 1;
+  string amount_uupx = 2;
+  string amount_uspx = 3;
+}

--- a/common/src/entities/daily-payment-txs/daily-payment-tx.firestore.ts
+++ b/common/src/entities/daily-payment-txs/daily-payment-tx.firestore.ts
@@ -1,0 +1,25 @@
+import { FirestoreDataConverter } from 'firebase/firestore';
+import { DailyPaymentTx } from './daily-payment-tx';
+
+
+export class DailyPaymentTxFirestore {
+  static collectionID = 'daily_payment_txs';
+  static documentID = 'daily_payment_tx_id';
+  static virtualPath = `${DailyPaymentTxFirestore.collectionID}/{${DailyPaymentTxFirestore.documentID}}`;
+
+  static converter: FirestoreDataConverter<DailyPaymentTx> = {
+    toFirestore: (data) => ({ ...data }),
+    fromFirestore: (snapshot, options) => {
+      const data = snapshot.data(options)!;
+      return new DailyPaymentTx(data, data.created_at, data.updated_at);
+    }
+  };
+
+  static collectionPath() {
+    return `${DailyPaymentTxFirestore.collectionID}`;
+  }
+
+  static documentPath(id: string) {
+    return `${DailyPaymentTxFirestore.collectionPath()}/${id}`;
+  }
+}

--- a/common/src/entities/daily-payment-txs/daily-payment-tx.ts
+++ b/common/src/entities/daily-payment-txs/daily-payment-tx.ts
@@ -1,0 +1,12 @@
+import { proto } from '../..';
+import { FieldValue, Timestamp } from 'firebase/firestore';
+
+export class DailyPaymentTx extends proto.main.DailyPaymentTx {
+  constructor(iDailyPaymentTx: proto.main.IDailyPaymentTx, public created_at?: FieldValue | Timestamp, public updated_at?: FieldValue | Timestamp) {
+    super(iDailyPaymentTx);
+  }
+
+  validate() {
+    return false;
+  }
+}

--- a/common/src/entities/daily-payment-txs/index.ts
+++ b/common/src/entities/daily-payment-txs/index.ts
@@ -1,0 +1,2 @@
+export * from './daily-payment-tx.firestore';
+export * from './daily-payment-tx';

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -46,3 +46,4 @@ export * from './entities/cost-settings';
 export * from './entities/delta-amounts';
 export * from './entities/renewable-reward-settings';
 export * from './entities/renewable-rankings';
+export * from './entities/daily-payment-txs';

--- a/common/src/proto.cjs
+++ b/common/src/proto.cjs
@@ -3136,6 +3136,445 @@
             return DailyPayment;
         })();
     
+        main.DailyPaymentTx = (function() {
+    
+            /**
+             * Properties of a DailyPaymentTx.
+             * @memberof main
+             * @interface IDailyPaymentTx
+             * @property {string|null} [id] DailyPaymentTx id
+             * @property {Array.<main.Ipayment>|null} [txs] DailyPaymentTx txs
+             */
+    
+            /**
+             * Constructs a new DailyPaymentTx.
+             * @memberof main
+             * @classdesc Represents a DailyPaymentTx.
+             * @implements IDailyPaymentTx
+             * @constructor
+             * @param {main.IDailyPaymentTx=} [properties] Properties to set
+             */
+            function DailyPaymentTx(properties) {
+                this.txs = [];
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * DailyPaymentTx id.
+             * @member {string} id
+             * @memberof main.DailyPaymentTx
+             * @instance
+             */
+            DailyPaymentTx.prototype.id = "";
+    
+            /**
+             * DailyPaymentTx txs.
+             * @member {Array.<main.Ipayment>} txs
+             * @memberof main.DailyPaymentTx
+             * @instance
+             */
+            DailyPaymentTx.prototype.txs = $util.emptyArray;
+    
+            /**
+             * Encodes the specified DailyPaymentTx message. Does not implicitly {@link main.DailyPaymentTx.verify|verify} messages.
+             * @function encode
+             * @memberof main.DailyPaymentTx
+             * @static
+             * @param {main.IDailyPaymentTx} message DailyPaymentTx message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DailyPaymentTx.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.txs != null && message.txs.length)
+                    for (var i = 0; i < message.txs.length; ++i)
+                        $root.main.payment.encode(message.txs[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified DailyPaymentTx message, length delimited. Does not implicitly {@link main.DailyPaymentTx.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.DailyPaymentTx
+             * @static
+             * @param {main.IDailyPaymentTx} message DailyPaymentTx message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            DailyPaymentTx.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a DailyPaymentTx message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.DailyPaymentTx
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.DailyPaymentTx} DailyPaymentTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DailyPaymentTx.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.DailyPaymentTx();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        if (!(message.txs && message.txs.length))
+                            message.txs = [];
+                        message.txs.push($root.main.payment.decode(reader, reader.uint32()));
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a DailyPaymentTx message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.DailyPaymentTx
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.DailyPaymentTx} DailyPaymentTx
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            DailyPaymentTx.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a DailyPaymentTx message.
+             * @function verify
+             * @memberof main.DailyPaymentTx
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            DailyPaymentTx.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.txs != null && message.hasOwnProperty("txs")) {
+                    if (!Array.isArray(message.txs))
+                        return "txs: array expected";
+                    for (var i = 0; i < message.txs.length; ++i) {
+                        var error = $root.main.payment.verify(message.txs[i]);
+                        if (error)
+                            return "txs." + error;
+                    }
+                }
+                return null;
+            };
+    
+            /**
+             * Creates a DailyPaymentTx message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.DailyPaymentTx
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.DailyPaymentTx} DailyPaymentTx
+             */
+            DailyPaymentTx.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.DailyPaymentTx)
+                    return object;
+                var message = new $root.main.DailyPaymentTx();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.txs) {
+                    if (!Array.isArray(object.txs))
+                        throw TypeError(".main.DailyPaymentTx.txs: array expected");
+                    message.txs = [];
+                    for (var i = 0; i < object.txs.length; ++i) {
+                        if (typeof object.txs[i] !== "object")
+                            throw TypeError(".main.DailyPaymentTx.txs: object expected");
+                        message.txs[i] = $root.main.payment.fromObject(object.txs[i]);
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a DailyPaymentTx message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.DailyPaymentTx
+             * @static
+             * @param {main.DailyPaymentTx} message DailyPaymentTx
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            DailyPaymentTx.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.arrays || options.defaults)
+                    object.txs = [];
+                if (options.defaults)
+                    object.id = "";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.txs && message.txs.length) {
+                    object.txs = [];
+                    for (var j = 0; j < message.txs.length; ++j)
+                        object.txs[j] = $root.main.payment.toObject(message.txs[j], options);
+                }
+                return object;
+            };
+    
+            /**
+             * Converts this DailyPaymentTx to JSON.
+             * @function toJSON
+             * @memberof main.DailyPaymentTx
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            DailyPaymentTx.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return DailyPaymentTx;
+        })();
+    
+        main.payment = (function() {
+    
+            /**
+             * Properties of a payment.
+             * @memberof main
+             * @interface Ipayment
+             * @property {string|null} [student_account_id] payment student_account_id
+             * @property {string|null} [amount_uupx] payment amount_uupx
+             * @property {string|null} [amount_uspx] payment amount_uspx
+             */
+    
+            /**
+             * Constructs a new payment.
+             * @memberof main
+             * @classdesc Represents a payment.
+             * @implements Ipayment
+             * @constructor
+             * @param {main.Ipayment=} [properties] Properties to set
+             */
+            function payment(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * payment student_account_id.
+             * @member {string} student_account_id
+             * @memberof main.payment
+             * @instance
+             */
+            payment.prototype.student_account_id = "";
+    
+            /**
+             * payment amount_uupx.
+             * @member {string} amount_uupx
+             * @memberof main.payment
+             * @instance
+             */
+            payment.prototype.amount_uupx = "";
+    
+            /**
+             * payment amount_uspx.
+             * @member {string} amount_uspx
+             * @memberof main.payment
+             * @instance
+             */
+            payment.prototype.amount_uspx = "";
+    
+            /**
+             * Encodes the specified payment message. Does not implicitly {@link main.payment.verify|verify} messages.
+             * @function encode
+             * @memberof main.payment
+             * @static
+             * @param {main.Ipayment} message payment message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            payment.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.student_account_id);
+                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.amount_uupx);
+                if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified payment message, length delimited. Does not implicitly {@link main.payment.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.payment
+             * @static
+             * @param {main.Ipayment} message payment message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            payment.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a payment message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.payment
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.payment} payment
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            payment.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.payment();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.student_account_id = reader.string();
+                        break;
+                    case 2:
+                        message.amount_uupx = reader.string();
+                        break;
+                    case 3:
+                        message.amount_uspx = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a payment message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.payment
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.payment} payment
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            payment.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a payment message.
+             * @function verify
+             * @memberof main.payment
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            payment.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                    if (!$util.isString(message.student_account_id))
+                        return "student_account_id: string expected";
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    if (!$util.isString(message.amount_uupx))
+                        return "amount_uupx: string expected";
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    if (!$util.isString(message.amount_uspx))
+                        return "amount_uspx: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a payment message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.payment
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.payment} payment
+             */
+            payment.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.payment)
+                    return object;
+                var message = new $root.main.payment();
+                if (object.student_account_id != null)
+                    message.student_account_id = String(object.student_account_id);
+                if (object.amount_uupx != null)
+                    message.amount_uupx = String(object.amount_uupx);
+                if (object.amount_uspx != null)
+                    message.amount_uspx = String(object.amount_uspx);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a payment message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.payment
+             * @static
+             * @param {main.payment} message payment
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            payment.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.student_account_id = "";
+                    object.amount_uupx = "";
+                    object.amount_uspx = "";
+                }
+                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                    object.student_account_id = message.student_account_id;
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    object.amount_uupx = message.amount_uupx;
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    object.amount_uspx = message.amount_uspx;
+                return object;
+            };
+    
+            /**
+             * Converts this payment to JSON.
+             * @function toJSON
+             * @memberof main.payment
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            payment.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return payment;
+        })();
+    
         main.DailyUsage = (function() {
     
             /**

--- a/common/src/proto.d.ts
+++ b/common/src/proto.d.ts
@@ -1258,6 +1258,190 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
+    /** Properties of a DailyPaymentTx. */
+    interface IDailyPaymentTx {
+
+        /** DailyPaymentTx id */
+        id?: (string|null);
+
+        /** DailyPaymentTx txs */
+        txs?: (main.Ipayment[]|null);
+    }
+
+    /** Represents a DailyPaymentTx. */
+    class DailyPaymentTx implements IDailyPaymentTx {
+
+        /**
+         * Constructs a new DailyPaymentTx.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.IDailyPaymentTx);
+
+        /** DailyPaymentTx id. */
+        public id: string;
+
+        /** DailyPaymentTx txs. */
+        public txs: main.Ipayment[];
+
+        /**
+         * Encodes the specified DailyPaymentTx message. Does not implicitly {@link main.DailyPaymentTx.verify|verify} messages.
+         * @param message DailyPaymentTx message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.IDailyPaymentTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified DailyPaymentTx message, length delimited. Does not implicitly {@link main.DailyPaymentTx.verify|verify} messages.
+         * @param message DailyPaymentTx message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.IDailyPaymentTx, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a DailyPaymentTx message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns DailyPaymentTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.DailyPaymentTx;
+
+        /**
+         * Decodes a DailyPaymentTx message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns DailyPaymentTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.DailyPaymentTx;
+
+        /**
+         * Verifies a DailyPaymentTx message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a DailyPaymentTx message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns DailyPaymentTx
+         */
+        public static fromObject(object: { [k: string]: any }): main.DailyPaymentTx;
+
+        /**
+         * Creates a plain object from a DailyPaymentTx message. Also converts values to other types if specified.
+         * @param message DailyPaymentTx
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.DailyPaymentTx, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this DailyPaymentTx to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a payment. */
+    interface Ipayment {
+
+        /** payment student_account_id */
+        student_account_id?: (string|null);
+
+        /** payment amount_uupx */
+        amount_uupx?: (string|null);
+
+        /** payment amount_uspx */
+        amount_uspx?: (string|null);
+    }
+
+    /** Represents a payment. */
+    class payment implements Ipayment {
+
+        /**
+         * Constructs a new payment.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.Ipayment);
+
+        /** payment student_account_id. */
+        public student_account_id: string;
+
+        /** payment amount_uupx. */
+        public amount_uupx: string;
+
+        /** payment amount_uspx. */
+        public amount_uspx: string;
+
+        /**
+         * Encodes the specified payment message. Does not implicitly {@link main.payment.verify|verify} messages.
+         * @param message payment message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.Ipayment, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified payment message, length delimited. Does not implicitly {@link main.payment.verify|verify} messages.
+         * @param message payment message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.Ipayment, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a payment message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns payment
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.payment;
+
+        /**
+         * Decodes a payment message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns payment
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.payment;
+
+        /**
+         * Verifies a payment message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a payment message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns payment
+         */
+        public static fromObject(object: { [k: string]: any }): main.payment;
+
+        /**
+         * Creates a plain object from a payment message. Also converts values to other types if specified.
+         * @param message payment
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.payment, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this payment to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
     /** Properties of a DailyUsage. */
     interface IDailyUsage {
 

--- a/common/src/proto.js
+++ b/common/src/proto.js
@@ -3127,6 +3127,445 @@ export const main = $root.main = (() => {
         return DailyPayment;
     })();
 
+    main.DailyPaymentTx = (function() {
+
+        /**
+         * Properties of a DailyPaymentTx.
+         * @memberof main
+         * @interface IDailyPaymentTx
+         * @property {string|null} [id] DailyPaymentTx id
+         * @property {Array.<main.Ipayment>|null} [txs] DailyPaymentTx txs
+         */
+
+        /**
+         * Constructs a new DailyPaymentTx.
+         * @memberof main
+         * @classdesc Represents a DailyPaymentTx.
+         * @implements IDailyPaymentTx
+         * @constructor
+         * @param {main.IDailyPaymentTx=} [properties] Properties to set
+         */
+        function DailyPaymentTx(properties) {
+            this.txs = [];
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * DailyPaymentTx id.
+         * @member {string} id
+         * @memberof main.DailyPaymentTx
+         * @instance
+         */
+        DailyPaymentTx.prototype.id = "";
+
+        /**
+         * DailyPaymentTx txs.
+         * @member {Array.<main.Ipayment>} txs
+         * @memberof main.DailyPaymentTx
+         * @instance
+         */
+        DailyPaymentTx.prototype.txs = $util.emptyArray;
+
+        /**
+         * Encodes the specified DailyPaymentTx message. Does not implicitly {@link main.DailyPaymentTx.verify|verify} messages.
+         * @function encode
+         * @memberof main.DailyPaymentTx
+         * @static
+         * @param {main.IDailyPaymentTx} message DailyPaymentTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DailyPaymentTx.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.txs != null && message.txs.length)
+                for (let i = 0; i < message.txs.length; ++i)
+                    $root.main.payment.encode(message.txs[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified DailyPaymentTx message, length delimited. Does not implicitly {@link main.DailyPaymentTx.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.DailyPaymentTx
+         * @static
+         * @param {main.IDailyPaymentTx} message DailyPaymentTx message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        DailyPaymentTx.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a DailyPaymentTx message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.DailyPaymentTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.DailyPaymentTx} DailyPaymentTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DailyPaymentTx.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.DailyPaymentTx();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    if (!(message.txs && message.txs.length))
+                        message.txs = [];
+                    message.txs.push($root.main.payment.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a DailyPaymentTx message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.DailyPaymentTx
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.DailyPaymentTx} DailyPaymentTx
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        DailyPaymentTx.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a DailyPaymentTx message.
+         * @function verify
+         * @memberof main.DailyPaymentTx
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        DailyPaymentTx.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.txs != null && message.hasOwnProperty("txs")) {
+                if (!Array.isArray(message.txs))
+                    return "txs: array expected";
+                for (let i = 0; i < message.txs.length; ++i) {
+                    let error = $root.main.payment.verify(message.txs[i]);
+                    if (error)
+                        return "txs." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a DailyPaymentTx message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.DailyPaymentTx
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.DailyPaymentTx} DailyPaymentTx
+         */
+        DailyPaymentTx.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.DailyPaymentTx)
+                return object;
+            let message = new $root.main.DailyPaymentTx();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.txs) {
+                if (!Array.isArray(object.txs))
+                    throw TypeError(".main.DailyPaymentTx.txs: array expected");
+                message.txs = [];
+                for (let i = 0; i < object.txs.length; ++i) {
+                    if (typeof object.txs[i] !== "object")
+                        throw TypeError(".main.DailyPaymentTx.txs: object expected");
+                    message.txs[i] = $root.main.payment.fromObject(object.txs[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a DailyPaymentTx message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.DailyPaymentTx
+         * @static
+         * @param {main.DailyPaymentTx} message DailyPaymentTx
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        DailyPaymentTx.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.arrays || options.defaults)
+                object.txs = [];
+            if (options.defaults)
+                object.id = "";
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.txs && message.txs.length) {
+                object.txs = [];
+                for (let j = 0; j < message.txs.length; ++j)
+                    object.txs[j] = $root.main.payment.toObject(message.txs[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this DailyPaymentTx to JSON.
+         * @function toJSON
+         * @memberof main.DailyPaymentTx
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        DailyPaymentTx.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return DailyPaymentTx;
+    })();
+
+    main.payment = (function() {
+
+        /**
+         * Properties of a payment.
+         * @memberof main
+         * @interface Ipayment
+         * @property {string|null} [student_account_id] payment student_account_id
+         * @property {string|null} [amount_uupx] payment amount_uupx
+         * @property {string|null} [amount_uspx] payment amount_uspx
+         */
+
+        /**
+         * Constructs a new payment.
+         * @memberof main
+         * @classdesc Represents a payment.
+         * @implements Ipayment
+         * @constructor
+         * @param {main.Ipayment=} [properties] Properties to set
+         */
+        function payment(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * payment student_account_id.
+         * @member {string} student_account_id
+         * @memberof main.payment
+         * @instance
+         */
+        payment.prototype.student_account_id = "";
+
+        /**
+         * payment amount_uupx.
+         * @member {string} amount_uupx
+         * @memberof main.payment
+         * @instance
+         */
+        payment.prototype.amount_uupx = "";
+
+        /**
+         * payment amount_uspx.
+         * @member {string} amount_uspx
+         * @memberof main.payment
+         * @instance
+         */
+        payment.prototype.amount_uspx = "";
+
+        /**
+         * Encodes the specified payment message. Does not implicitly {@link main.payment.verify|verify} messages.
+         * @function encode
+         * @memberof main.payment
+         * @static
+         * @param {main.Ipayment} message payment message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        payment.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.student_account_id);
+            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.amount_uupx);
+            if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified payment message, length delimited. Does not implicitly {@link main.payment.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.payment
+         * @static
+         * @param {main.Ipayment} message payment message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        payment.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a payment message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.payment
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.payment} payment
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        payment.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.payment();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.student_account_id = reader.string();
+                    break;
+                case 2:
+                    message.amount_uupx = reader.string();
+                    break;
+                case 3:
+                    message.amount_uspx = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a payment message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.payment
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.payment} payment
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        payment.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a payment message.
+         * @function verify
+         * @memberof main.payment
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        payment.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                if (!$util.isString(message.student_account_id))
+                    return "student_account_id: string expected";
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                if (!$util.isString(message.amount_uupx))
+                    return "amount_uupx: string expected";
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                if (!$util.isString(message.amount_uspx))
+                    return "amount_uspx: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a payment message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.payment
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.payment} payment
+         */
+        payment.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.payment)
+                return object;
+            let message = new $root.main.payment();
+            if (object.student_account_id != null)
+                message.student_account_id = String(object.student_account_id);
+            if (object.amount_uupx != null)
+                message.amount_uupx = String(object.amount_uupx);
+            if (object.amount_uspx != null)
+                message.amount_uspx = String(object.amount_uspx);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a payment message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.payment
+         * @static
+         * @param {main.payment} message payment
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        payment.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.student_account_id = "";
+                object.amount_uupx = "";
+                object.amount_uspx = "";
+            }
+            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                object.student_account_id = message.student_account_id;
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                object.amount_uupx = message.amount_uupx;
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                object.amount_uspx = message.amount_uspx;
+            return object;
+        };
+
+        /**
+         * Converts this payment to JSON.
+         * @function toJSON
+         * @memberof main.payment
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        payment.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return payment;
+    })();
+
     main.DailyUsage = (function() {
 
         /**

--- a/functions/src/daily-payment-txs/controller.ts
+++ b/functions/src/daily-payment-txs/controller.ts
@@ -1,0 +1,55 @@
+import { FirestoreCreateHandler, FirestoreDeleteHandler, FirestoreUpdateHandler } from '../triggers';
+import { isTriggeredOnce } from '../triggers/module';
+import { DailyPaymentTxFirestore } from '@local/common';
+import * as functions from 'firebase-functions';
+
+export const onCreateHandler: FirestoreCreateHandler[] = [];
+export const onUpdateHandler: FirestoreUpdateHandler[] = [];
+export const onDeleteHandler: FirestoreDeleteHandler[] = [];
+
+const f = functions.region('asia-northeast1').runWith({ timeoutSeconds: 540, memory: '2GB', secrets: ['PRIV_KEY'] });
+
+module.exports.onCreate = f.firestore.document(DailyPaymentTxFirestore.virtualPath).onCreate(async (snapshot, context) => {
+  if (await isTriggeredOnce(context.eventId)) {
+    return;
+  }
+
+  for (const handler of onCreateHandler) {
+    try {
+      await handler(snapshot, context);
+    } catch (e) {
+      console.error(`Error: in function ${handler.name}`);
+      console.error(e);
+    }
+  }
+});
+
+// export const onUpdate = functions.firestore.document(DailyPaymentTxFirestore.virtualPath).onUpdate(async (snapshot, context) => {
+//   if (await isTriggeredOnce(context.eventId)) {
+//     return;
+//   }
+
+//   for (const handler of onUpdateHandler) {
+//     try {
+//       await handler(snapshot, context);
+//     } catch (e) {
+//       console.error(`Error: in function ${handler.name}`);
+//       console.error(e);
+//     }
+//   }
+// });
+
+// export const onDelete = functions.firestore.document(DailyPaymentTxFirestore.virtualPath).onDelete(async (snapshot, context) => {
+//   if (await isTriggeredOnce(context.eventId)) {
+//     return;
+//   }
+
+//   for (const handler of onDeleteHandler) {
+//     try {
+//       await handler(snapshot, context);
+//     } catch (e) {
+//       console.error(`Error: in function ${handler.name}`);
+//       console.error(e);
+//     }
+//   }
+// });

--- a/functions/src/daily-payment-txs/index.ts
+++ b/functions/src/daily-payment-txs/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line camelcase
+export * as daily_payment_tx from './module';

--- a/functions/src/daily-payment-txs/module.ts
+++ b/functions/src/daily-payment-txs/module.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+/* eslint-disable require-jsdoc */
+import * as admin from 'firebase-admin';
+import { DailyPaymentTx, DailyPaymentTxFirestore } from '@local/common';
+
+export * from './controller'
+
+export function collection() {
+  return admin
+    .firestore()
+    .collection(DailyPaymentTxFirestore.collectionPath())
+    .withConverter(DailyPaymentTxFirestore.converter as any);
+}
+
+export function collectionGroup() {
+  return admin
+    .firestore()
+    .collectionGroup(DailyPaymentTxFirestore.collectionID)
+    .withConverter(DailyPaymentTxFirestore.converter as any);
+}
+
+export function document(id?: string) {
+  const col = collection();
+  return id ? col.doc(id) : col.doc();
+}
+
+export async function get(id: string) {
+  return await document(id)
+    .get()
+    .then((snapshot) => snapshot.data() as DailyPaymentTx | undefined);
+}
+
+export async function list() {
+  return await collection()
+    .get()
+    .then((snapshot) => snapshot.docs.map((doc) => doc.data() as DailyPaymentTx));
+}
+
+export async function create(
+  data: DailyPaymentTx
+) {
+  const doc = document(data.id);
+  data.id = doc.id;
+
+  const now = admin.firestore.Timestamp.now();
+  data.created_at = now;
+  data.updated_at = now;
+
+  await doc.set(data);
+}
+
+export async function update(
+  data: Partial<DailyPaymentTx> & { id: string }
+) {
+  const now = admin.firestore.Timestamp.now();
+  data.updated_at = now;
+
+  await document(data.id).update(data);
+}
+
+export async function delete_(id: string) {
+  await document(id).delete();
+}

--- a/functions/src/daily-payment-txs/send-txs.ts
+++ b/functions/src/daily-payment-txs/send-txs.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+/* eslint-disable camelcase */
+import { daily_payment_tx } from '.';
+import { account_private } from '../account-privates';
+import { admin_account } from '../admin-accounts';
+import { DailyPaymentTx } from '@local/common';
+import * as crypto from 'crypto-js';
+
+daily_payment_tx.onCreateHandler.push(async (snapshot, context) => {
+  const data = snapshot.data()! as DailyPaymentTx;
+  const txs = data.txs;
+  const privKey = process.env.PRIV_KEY;
+  if (!privKey) {
+    console.log('no privKey');
+    return;
+  }
+  let slicedTxs;
+  if (data.txs.length > 10) {
+    slicedTxs = txs.slice(0, 9);
+  } else {
+    slicedTxs = txs;
+  }
+  for (const tx of slicedTxs) {
+    if (tx.student_account_id) {
+      const accountPrivate = await account_private.list(tx.student_account_id);
+      if (accountPrivate.length) {
+        const adminAccount = await admin_account.getByName('admin');
+
+        const xrpl = require('xrpl');
+        const TEST_NET = 'wss://s.altnet.rippletest.net:51233';
+        const client = new xrpl.Client(TEST_NET);
+
+        const decrypted = crypto.AES.decrypt(accountPrivate[0].xrp_seed, privKey).toString(crypto.enc.Utf8);
+
+        if (tx.amount_uupx && tx.amount_uupx != '0') {
+          await client.connect();
+          const sender = xrpl.Wallet.fromSeed(decrypted);
+          const vli = await client.getLedgerIndex();
+          const sendUPXTx = {
+            TransactionType: 'Payment',
+            Account: sender.address,
+            Amount: {
+              currency: 'UPX',
+              value: (parseInt(tx.amount_uupx) / 1000000).toString(),
+              issuer: adminAccount[0].xrp_address_cold,
+            },
+            Destination: adminAccount[0].xrp_address_hot,
+            LastLedgerSequence: vli + 540,
+          };
+          const payPreparedUPX = await client.autofill(sendUPXTx);
+          const paySignedUPX = sender.sign(payPreparedUPX);
+          const payResultUPX = await client.submitAndWait(paySignedUPX.tx_blob);
+          if (payResultUPX.result.meta.TransactionResult == 'tesSUCCESS') {
+            console.log(`Transaction succeeded: https://testnet.xrpl.org/transactions/${paySignedUPX.hash}`);
+          } else {
+            // eslint-disable-next-line no-throw-literal
+            throw `${tx.student_account_id} UPX Error sending transaction: ${payResultUPX.result.meta.TransactionResult}`;
+          }
+          await client.disconnect();
+        }
+
+        if (tx.amount_uspx && tx.amount_uspx != '0') {
+          await client.connect();
+          const sender = xrpl.Wallet.fromSeed(decrypted);
+          const vli = await client.getLedgerIndex();
+          const sendSPXTx = {
+            TransactionType: 'Payment',
+            Account: sender.address,
+            Amount: {
+              currency: 'SPX',
+              value: (parseInt(tx.amount_uspx) / 1000000).toString(),
+              issuer: adminAccount[0].xrp_address_cold,
+            },
+            Destination: adminAccount[0].xrp_address_hot,
+            LastLedgerSequence: vli + 540,
+          };
+          const payPreparedSPX = await client.autofill(sendSPXTx);
+          const paySignedSPX = sender.sign(payPreparedSPX);
+          const payResultSPX = await client.submitAndWait(paySignedSPX.tx_blob);
+          if (payResultSPX.result.meta.TransactionResult == 'tesSUCCESS') {
+            console.log(`Transaction succeeded: https://testnet.xrpl.org/transactions/${paySignedSPX.hash}`);
+          } else {
+            // eslint-disable-next-line no-throw-literal
+            throw `${tx.student_account_id} SPX Error sending transaction: ${payResultSPX.result.meta.TransactionResult}`;
+          }
+          await await client.disconnect();
+        }
+      }
+    }
+  }
+  if (data.txs.length > 10) {
+    const nextTxs = txs.slice(10);
+    const nextdailyPaymentTxs = new DailyPaymentTx({ txs: nextTxs });
+    daily_payment_tx.create(nextdailyPaymentTxs);
+  }
+});

--- a/functions/src/daily-payments/create-balance.ts
+++ b/functions/src/daily-payments/create-balance.ts
@@ -2,12 +2,13 @@
 
 /* eslint-disable camelcase */
 // import { daily_payment } from '.';
-import { account_private } from '../account-privates';
-import { admin_account } from '../admin-accounts';
+// import { account_private } from '../account-privates';
+// import { admin_account } from '../admin-accounts';
 import { balance } from '../balances';
 import { insufficient_balance } from '../insufficient-balances';
 import { InsufficientBalance, DailyPayment, Balance } from '@local/common';
-import * as crypto from 'crypto-js';
+
+// import * as crypto from 'crypto-js';
 
 // daily_payment.onCreateHandler.push()
 export const dailyPaymentOnCreate = async (snapshot: any, context: any) => {
@@ -27,75 +28,75 @@ export const dailyPaymentOnCreate = async (snapshot: any, context: any) => {
     );
   }
 
-  const accountPrivate = await account_private.list(data.student_account_id);
-  if (!accountPrivate.length) {
-    console.log(data.student_account_id, 'no XRP address');
-    return;
-  }
-  const adminAccount = await admin_account.getByName('admin');
+  // const accountPrivate = await account_private.list(data.student_account_id);
+  // if (!accountPrivate.length) {
+  //   console.log(data.student_account_id, 'no XRP address');
+  //   return;
+  // }
+  // const adminAccount = await admin_account.getByName('admin');
 
-  const xrpl = require('xrpl');
-  const TEST_NET = 'wss://s.altnet.rippletest.net:51233';
-  const client = new xrpl.Client(TEST_NET);
+  // const xrpl = require('xrpl');
+  // const TEST_NET = 'wss://s.altnet.rippletest.net:51233';
+  // const client = new xrpl.Client(TEST_NET);
 
-  const privKey = process.env.PRIV_KEY;
-  if (!privKey) {
-    console.log('no privKey');
-    return;
-  }
-  const decrypted = crypto.AES.decrypt(accountPrivate[0].xrp_seed, privKey).toString(crypto.enc.Utf8);
+  // const privKey = process.env.PRIV_KEY;
+  // if (!privKey) {
+  //   console.log('no privKey');
+  //   return;
+  // }
+  // const decrypted = crypto.AES.decrypt(accountPrivate[0].xrp_seed, privKey).toString(crypto.enc.Utf8);
 
-  if (data.amount_uupx != '0') {
-    await client.connect();
-    const sender = xrpl.Wallet.fromSeed(decrypted);
-    const vli = await client.getLedgerIndex();
-    const sendUPXTx = {
-      TransactionType: 'Payment',
-      Account: sender.address,
-      Amount: {
-        currency: 'UPX',
-        value: (parseInt(data.amount_uupx) / 1000000).toString(),
-        issuer: adminAccount[0].xrp_address_cold,
-      },
-      Destination: adminAccount[0].xrp_address_hot,
-      LastLedgerSequence: vli + 540,
-    };
-    const payPreparedUPX = await client.autofill(sendUPXTx);
-    const paySignedUPX = sender.sign(payPreparedUPX);
-    const payResultUPX = await client.submitAndWait(paySignedUPX.tx_blob);
-    if (payResultUPX.result.meta.TransactionResult == 'tesSUCCESS') {
-      console.log(`Transaction succeeded: https://testnet.xrpl.org/transactions/${paySignedUPX.hash}`);
-    } else {
-      // eslint-disable-next-line no-throw-literal
-      throw `${data.student_account_id} UPX Error sending transaction: ${payResultUPX.result.meta.TransactionResult}`;
-    }
-    await client.disconnect();
-  }
+  // if (data.amount_uupx != '0') {
+  //   await client.connect();
+  //   const sender = xrpl.Wallet.fromSeed(decrypted);
+  //   const vli = await client.getLedgerIndex();
+  //   const sendUPXTx = {
+  //     TransactionType: 'Payment',
+  //     Account: sender.address,
+  //     Amount: {
+  //       currency: 'UPX',
+  //       value: (parseInt(data.amount_uupx) / 1000000).toString(),
+  //       issuer: adminAccount[0].xrp_address_cold,
+  //     },
+  //     Destination: adminAccount[0].xrp_address_hot,
+  //     LastLedgerSequence: vli + 540,
+  //   };
+  //   const payPreparedUPX = await client.autofill(sendUPXTx);
+  //   const paySignedUPX = sender.sign(payPreparedUPX);
+  //   const payResultUPX = await client.submitAndWait(paySignedUPX.tx_blob);
+  //   if (payResultUPX.result.meta.TransactionResult == 'tesSUCCESS') {
+  //     console.log(`Transaction succeeded: https://testnet.xrpl.org/transactions/${paySignedUPX.hash}`);
+  //   } else {
+  //     // eslint-disable-next-line no-throw-literal
+  //     throw `${data.student_account_id} UPX Error sending transaction: ${payResultUPX.result.meta.TransactionResult}`;
+  //   }
+  //   await client.disconnect();
+  // }
 
-  if (data.amount_uspx != '0') {
-    await client.connect();
-    const sender = xrpl.Wallet.fromSeed(decrypted);
-    const vli = await client.getLedgerIndex();
-    const sendSPXTx = {
-      TransactionType: 'Payment',
-      Account: sender.address,
-      Amount: {
-        currency: 'SPX',
-        value: (parseInt(data.amount_uspx) / 1000000).toString(),
-        issuer: adminAccount[0].xrp_address_cold,
-      },
-      Destination: adminAccount[0].xrp_address_hot,
-      LastLedgerSequence: vli + 540,
-    };
-    const payPreparedSPX = await client.autofill(sendSPXTx);
-    const paySignedSPX = sender.sign(payPreparedSPX);
-    const payResultSPX = await client.submitAndWait(paySignedSPX.tx_blob);
-    if (payResultSPX.result.meta.TransactionResult == 'tesSUCCESS') {
-      console.log(`Transaction succeeded: https://testnet.xrpl.org/transactions/${paySignedSPX.hash}`);
-    } else {
-      // eslint-disable-next-line no-throw-literal
-      throw `${data.student_account_id} SPX Error sending transaction: ${payResultSPX.result.meta.TransactionResult}`;
-    }
-    await await client.disconnect();
-  }
+  // if (data.amount_uspx != '0') {
+  //   await client.connect();
+  //   const sender = xrpl.Wallet.fromSeed(decrypted);
+  //   const vli = await client.getLedgerIndex();
+  //   const sendSPXTx = {
+  //     TransactionType: 'Payment',
+  //     Account: sender.address,
+  //     Amount: {
+  //       currency: 'SPX',
+  //       value: (parseInt(data.amount_uspx) / 1000000).toString(),
+  //       issuer: adminAccount[0].xrp_address_cold,
+  //     },
+  //     Destination: adminAccount[0].xrp_address_hot,
+  //     LastLedgerSequence: vli + 540,
+  //   };
+  //   const payPreparedSPX = await client.autofill(sendSPXTx);
+  //   const paySignedSPX = sender.sign(payPreparedSPX);
+  //   const payResultSPX = await client.submitAndWait(paySignedSPX.tx_blob);
+  //   if (payResultSPX.result.meta.TransactionResult == 'tesSUCCESS') {
+  //     console.log(`Transaction succeeded: https://testnet.xrpl.org/transactions/${paySignedSPX.hash}`);
+  //   } else {
+  //     // eslint-disable-next-line no-throw-literal
+  //     throw `${data.student_account_id} SPX Error sending transaction: ${payResultSPX.result.meta.TransactionResult}`;
+  //   }
+  //   await await client.disconnect();
+  // }
 };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -50,6 +50,7 @@ const files = {
   chats: './chats',
   cost_settings: './cost-settings',
   daily_payment: './daily-payments',
+  daily_payment_tx: './daily-payment-txs',
   daily_usages: './daily-usages',
   delta_amounts: './delta-amounts',
   discount_prices: './discount-prices',


### PR DESCRIPTION
close #292 

ブロックチェーンのトランザクションを並列で処理できないため，専用のドキュメントにTxの配列を作成し，それのOnCreateで発火，すべてのトランザクションを直列で処理していく。
このPRの修正前はおそらく50アカウントほどで処理時間の上限に引っかかると思われる。

540秒の時間制限があるため，10件処理→10件除いて新しいドキュメントを作成→次の10件処理とやっていく。