### PR TITLE
月末の精算を一部1日の計算から除外

### DIFF
--- a/common/proto/monthly_payments/monthly_payment.proto
+++ b/common/proto/monthly_payments/monthly_payment.proto
@@ -15,4 +15,5 @@ message MonthlyPayment {
   string amount_adjust_ujpy = 7;
   string amount_market_ujpy = 8;
   string amount_reward_ujpy = 9;
+  string amount_utoken = 10;
 }

--- a/common/proto/monthly_settlements/monthly_settlement.proto
+++ b/common/proto/monthly_settlements/monthly_settlement.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+package main;
+
+import "firebase_rules_options.proto";
+
+option (google.firebase.rules.firebase_rules).full_package_names = true;
+
+message MonthlySettlement {
+  string id = 1;
+  string year = 2;
+  string month = 3;
+  string reward_ujpy = 4;
+  string system_income_ujpy = 5;
+  string purchase_utoken = 6;
+  string sale_utoken = 7;
+}

--- a/common/src/entities/monthly-settlements/index.ts
+++ b/common/src/entities/monthly-settlements/index.ts
@@ -1,0 +1,2 @@
+export * from './monthly-settlement.firestore';
+export * from './monthly-settlement';

--- a/common/src/entities/monthly-settlements/monthly-settlement.firestore.ts
+++ b/common/src/entities/monthly-settlements/monthly-settlement.firestore.ts
@@ -1,0 +1,25 @@
+import { FirestoreDataConverter } from 'firebase/firestore';
+import { MonthlySettlement } from './monthly-settlement';
+
+
+export class MonthlySettlementFirestore {
+  static collectionID = 'monthly_settlements';
+  static documentID = 'monthly_settlement_id';
+  static virtualPath = `${MonthlySettlementFirestore.collectionID}/{${MonthlySettlementFirestore.documentID}}`;
+
+  static converter: FirestoreDataConverter<MonthlySettlement> = {
+    toFirestore: (data) => ({ ...data }),
+    fromFirestore: (snapshot, options) => {
+      const data = snapshot.data(options)!;
+      return new MonthlySettlement(data, data.created_at, data.updated_at);
+    }
+  };
+
+  static collectionPath() {
+    return `${MonthlySettlementFirestore.collectionID}`;
+  }
+
+  static documentPath(id: string) {
+    return `${MonthlySettlementFirestore.collectionPath()}/${id}`;
+  }
+}

--- a/common/src/entities/monthly-settlements/monthly-settlement.ts
+++ b/common/src/entities/monthly-settlements/monthly-settlement.ts
@@ -1,0 +1,12 @@
+import { proto } from '../..';
+import { FieldValue, Timestamp } from 'firebase/firestore';
+
+export class MonthlySettlement extends proto.main.MonthlySettlement {
+  constructor(iMonthlySettlement: proto.main.IMonthlySettlement, public created_at?: FieldValue | Timestamp, public updated_at?: FieldValue | Timestamp) {
+    super(iMonthlySettlement);
+  }
+
+  validate() {
+    return false;
+  }
+}

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -46,3 +46,4 @@ export * from './entities/cost-settings';
 export * from './entities/delta-amounts';
 export * from './entities/renewable-reward-settings';
 export * from './entities/renewable-rankings';
+export * from './entities/monthly-settlements';

--- a/common/src/proto.cjs
+++ b/common/src/proto.cjs
@@ -25,226 +25,6 @@
          */
         var main = {};
     
-        main.AccountantAccount = (function() {
-    
-            /**
-             * Properties of an AccountantAccount.
-             * @memberof main
-             * @interface IAccountantAccount
-             * @property {string|null} [id] AccountantAccount id
-             * @property {string|null} [name] AccountantAccount name
-             * @property {string|null} [xrp_address] AccountantAccount xrp_address
-             */
-    
-            /**
-             * Constructs a new AccountantAccount.
-             * @memberof main
-             * @classdesc Represents an AccountantAccount.
-             * @implements IAccountantAccount
-             * @constructor
-             * @param {main.IAccountantAccount=} [properties] Properties to set
-             */
-            function AccountantAccount(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * AccountantAccount id.
-             * @member {string} id
-             * @memberof main.AccountantAccount
-             * @instance
-             */
-            AccountantAccount.prototype.id = "";
-    
-            /**
-             * AccountantAccount name.
-             * @member {string} name
-             * @memberof main.AccountantAccount
-             * @instance
-             */
-            AccountantAccount.prototype.name = "";
-    
-            /**
-             * AccountantAccount xrp_address.
-             * @member {string} xrp_address
-             * @memberof main.AccountantAccount
-             * @instance
-             */
-            AccountantAccount.prototype.xrp_address = "";
-    
-            /**
-             * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-             * @function encode
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            AccountantAccount.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.name);
-                if (message.xrp_address != null && Object.hasOwnProperty.call(message, "xrp_address"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.xrp_address);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            AccountantAccount.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes an AccountantAccount message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.AccountantAccount} AccountantAccount
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            AccountantAccount.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.AccountantAccount();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.name = reader.string();
-                        break;
-                    case 3:
-                        message.xrp_address = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.AccountantAccount} AccountantAccount
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            AccountantAccount.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies an AccountantAccount message.
-             * @function verify
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            AccountantAccount.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.name != null && message.hasOwnProperty("name"))
-                    if (!$util.isString(message.name))
-                        return "name: string expected";
-                if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
-                    if (!$util.isString(message.xrp_address))
-                        return "xrp_address: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.AccountantAccount} AccountantAccount
-             */
-            AccountantAccount.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.AccountantAccount)
-                    return object;
-                var message = new $root.main.AccountantAccount();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.name != null)
-                    message.name = String(object.name);
-                if (object.xrp_address != null)
-                    message.xrp_address = String(object.xrp_address);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {main.AccountantAccount} message AccountantAccount
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            AccountantAccount.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.name = "";
-                    object.xrp_address = "";
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.name != null && message.hasOwnProperty("name"))
-                    object.name = message.name;
-                if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
-                    object.xrp_address = message.xrp_address;
-                return object;
-            };
-    
-            /**
-             * Converts this AccountantAccount to JSON.
-             * @function toJSON
-             * @memberof main.AccountantAccount
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            AccountantAccount.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return AccountantAccount;
-        })();
-    
         main.AccountPrivate = (function() {
     
             /**
@@ -485,6 +265,226 @@
             };
     
             return AccountPrivate;
+        })();
+    
+        main.AccountantAccount = (function() {
+    
+            /**
+             * Properties of an AccountantAccount.
+             * @memberof main
+             * @interface IAccountantAccount
+             * @property {string|null} [id] AccountantAccount id
+             * @property {string|null} [name] AccountantAccount name
+             * @property {string|null} [xrp_address] AccountantAccount xrp_address
+             */
+    
+            /**
+             * Constructs a new AccountantAccount.
+             * @memberof main
+             * @classdesc Represents an AccountantAccount.
+             * @implements IAccountantAccount
+             * @constructor
+             * @param {main.IAccountantAccount=} [properties] Properties to set
+             */
+            function AccountantAccount(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * AccountantAccount id.
+             * @member {string} id
+             * @memberof main.AccountantAccount
+             * @instance
+             */
+            AccountantAccount.prototype.id = "";
+    
+            /**
+             * AccountantAccount name.
+             * @member {string} name
+             * @memberof main.AccountantAccount
+             * @instance
+             */
+            AccountantAccount.prototype.name = "";
+    
+            /**
+             * AccountantAccount xrp_address.
+             * @member {string} xrp_address
+             * @memberof main.AccountantAccount
+             * @instance
+             */
+            AccountantAccount.prototype.xrp_address = "";
+    
+            /**
+             * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+             * @function encode
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            AccountantAccount.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.name);
+                if (message.xrp_address != null && Object.hasOwnProperty.call(message, "xrp_address"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.xrp_address);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            AccountantAccount.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes an AccountantAccount message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.AccountantAccount} AccountantAccount
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            AccountantAccount.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.AccountantAccount();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.name = reader.string();
+                        break;
+                    case 3:
+                        message.xrp_address = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.AccountantAccount} AccountantAccount
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            AccountantAccount.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies an AccountantAccount message.
+             * @function verify
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            AccountantAccount.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
+                    if (!$util.isString(message.xrp_address))
+                        return "xrp_address: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.AccountantAccount} AccountantAccount
+             */
+            AccountantAccount.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.AccountantAccount)
+                    return object;
+                var message = new $root.main.AccountantAccount();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object.xrp_address != null)
+                    message.xrp_address = String(object.xrp_address);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {main.AccountantAccount} message AccountantAccount
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            AccountantAccount.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.name = "";
+                    object.xrp_address = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
+                    object.xrp_address = message.xrp_address;
+                return object;
+            };
+    
+            /**
+             * Converts this AccountantAccount to JSON.
+             * @function toJSON
+             * @memberof main.AccountantAccount
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            AccountantAccount.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return AccountantAccount;
         })();
     
         /**
@@ -1574,248 +1574,6 @@
             return AvailableBalance;
         })();
     
-        main.Balance = (function() {
-    
-            /**
-             * Properties of a Balance.
-             * @memberof main
-             * @interface IBalance
-             * @property {string|null} [id] Balance id
-             * @property {string|null} [student_account_id] Balance student_account_id
-             * @property {string|null} [amount_uupx] Balance amount_uupx
-             * @property {string|null} [amount_uspx] Balance amount_uspx
-             */
-    
-            /**
-             * Constructs a new Balance.
-             * @memberof main
-             * @classdesc Represents a Balance.
-             * @implements IBalance
-             * @constructor
-             * @param {main.IBalance=} [properties] Properties to set
-             */
-            function Balance(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * Balance id.
-             * @member {string} id
-             * @memberof main.Balance
-             * @instance
-             */
-            Balance.prototype.id = "";
-    
-            /**
-             * Balance student_account_id.
-             * @member {string} student_account_id
-             * @memberof main.Balance
-             * @instance
-             */
-            Balance.prototype.student_account_id = "";
-    
-            /**
-             * Balance amount_uupx.
-             * @member {string} amount_uupx
-             * @memberof main.Balance
-             * @instance
-             */
-            Balance.prototype.amount_uupx = "";
-    
-            /**
-             * Balance amount_uspx.
-             * @member {string} amount_uspx
-             * @memberof main.Balance
-             * @instance
-             */
-            Balance.prototype.amount_uspx = "";
-    
-            /**
-             * Encodes the specified Balance message. Does not implicitly {@link main.Balance.verify|verify} messages.
-             * @function encode
-             * @memberof main.Balance
-             * @static
-             * @param {main.IBalance} message Balance message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            Balance.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.student_account_id);
-                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
-                if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uspx);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified Balance message, length delimited. Does not implicitly {@link main.Balance.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.Balance
-             * @static
-             * @param {main.IBalance} message Balance message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            Balance.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a Balance message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.Balance
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.Balance} Balance
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            Balance.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.Balance();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.student_account_id = reader.string();
-                        break;
-                    case 3:
-                        message.amount_uupx = reader.string();
-                        break;
-                    case 4:
-                        message.amount_uspx = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a Balance message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.Balance
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.Balance} Balance
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            Balance.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a Balance message.
-             * @function verify
-             * @memberof main.Balance
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            Balance.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
-                    if (!$util.isString(message.student_account_id))
-                        return "student_account_id: string expected";
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    if (!$util.isString(message.amount_uupx))
-                        return "amount_uupx: string expected";
-                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                    if (!$util.isString(message.amount_uspx))
-                        return "amount_uspx: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates a Balance message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.Balance
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.Balance} Balance
-             */
-            Balance.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.Balance)
-                    return object;
-                var message = new $root.main.Balance();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.student_account_id != null)
-                    message.student_account_id = String(object.student_account_id);
-                if (object.amount_uupx != null)
-                    message.amount_uupx = String(object.amount_uupx);
-                if (object.amount_uspx != null)
-                    message.amount_uspx = String(object.amount_uspx);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a Balance message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.Balance
-             * @static
-             * @param {main.Balance} message Balance
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            Balance.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.student_account_id = "";
-                    object.amount_uupx = "";
-                    object.amount_uspx = "";
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
-                    object.student_account_id = message.student_account_id;
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    object.amount_uupx = message.amount_uupx;
-                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                    object.amount_uspx = message.amount_uspx;
-                return object;
-            };
-    
-            /**
-             * Converts this Balance to JSON.
-             * @function toJSON
-             * @memberof main.Balance
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            Balance.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return Balance;
-        })();
-    
         main.BalanceSnapshot = (function() {
     
             /**
@@ -2056,6 +1814,248 @@
             };
     
             return BalanceSnapshot;
+        })();
+    
+        main.Balance = (function() {
+    
+            /**
+             * Properties of a Balance.
+             * @memberof main
+             * @interface IBalance
+             * @property {string|null} [id] Balance id
+             * @property {string|null} [student_account_id] Balance student_account_id
+             * @property {string|null} [amount_uupx] Balance amount_uupx
+             * @property {string|null} [amount_uspx] Balance amount_uspx
+             */
+    
+            /**
+             * Constructs a new Balance.
+             * @memberof main
+             * @classdesc Represents a Balance.
+             * @implements IBalance
+             * @constructor
+             * @param {main.IBalance=} [properties] Properties to set
+             */
+            function Balance(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * Balance id.
+             * @member {string} id
+             * @memberof main.Balance
+             * @instance
+             */
+            Balance.prototype.id = "";
+    
+            /**
+             * Balance student_account_id.
+             * @member {string} student_account_id
+             * @memberof main.Balance
+             * @instance
+             */
+            Balance.prototype.student_account_id = "";
+    
+            /**
+             * Balance amount_uupx.
+             * @member {string} amount_uupx
+             * @memberof main.Balance
+             * @instance
+             */
+            Balance.prototype.amount_uupx = "";
+    
+            /**
+             * Balance amount_uspx.
+             * @member {string} amount_uspx
+             * @memberof main.Balance
+             * @instance
+             */
+            Balance.prototype.amount_uspx = "";
+    
+            /**
+             * Encodes the specified Balance message. Does not implicitly {@link main.Balance.verify|verify} messages.
+             * @function encode
+             * @memberof main.Balance
+             * @static
+             * @param {main.IBalance} message Balance message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Balance.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.student_account_id);
+                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
+                if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uspx);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified Balance message, length delimited. Does not implicitly {@link main.Balance.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.Balance
+             * @static
+             * @param {main.IBalance} message Balance message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            Balance.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a Balance message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.Balance
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.Balance} Balance
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Balance.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.Balance();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.student_account_id = reader.string();
+                        break;
+                    case 3:
+                        message.amount_uupx = reader.string();
+                        break;
+                    case 4:
+                        message.amount_uspx = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a Balance message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.Balance
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.Balance} Balance
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            Balance.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a Balance message.
+             * @function verify
+             * @memberof main.Balance
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            Balance.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                    if (!$util.isString(message.student_account_id))
+                        return "student_account_id: string expected";
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    if (!$util.isString(message.amount_uupx))
+                        return "amount_uupx: string expected";
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    if (!$util.isString(message.amount_uspx))
+                        return "amount_uspx: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a Balance message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.Balance
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.Balance} Balance
+             */
+            Balance.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.Balance)
+                    return object;
+                var message = new $root.main.Balance();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.student_account_id != null)
+                    message.student_account_id = String(object.student_account_id);
+                if (object.amount_uupx != null)
+                    message.amount_uupx = String(object.amount_uupx);
+                if (object.amount_uspx != null)
+                    message.amount_uspx = String(object.amount_uspx);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a Balance message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.Balance
+             * @static
+             * @param {main.Balance} message Balance
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            Balance.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.student_account_id = "";
+                    object.amount_uupx = "";
+                    object.amount_uspx = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                    object.student_account_id = message.student_account_id;
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    object.amount_uupx = message.amount_uupx;
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    object.amount_uspx = message.amount_uspx;
+                return object;
+            };
+    
+            /**
+             * Converts this Balance to JSON.
+             * @function toJSON
+             * @memberof main.Balance
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            Balance.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return Balance;
         })();
     
         main.ChatDelete = (function() {
@@ -4999,6 +4999,7 @@
              * @property {string|null} [amount_adjust_ujpy] MonthlyPayment amount_adjust_ujpy
              * @property {string|null} [amount_market_ujpy] MonthlyPayment amount_market_ujpy
              * @property {string|null} [amount_reward_ujpy] MonthlyPayment amount_reward_ujpy
+             * @property {string|null} [amount_utoken] MonthlyPayment amount_utoken
              */
     
             /**
@@ -5089,6 +5090,14 @@
             MonthlyPayment.prototype.amount_reward_ujpy = "";
     
             /**
+             * MonthlyPayment amount_utoken.
+             * @member {string} amount_utoken
+             * @memberof main.MonthlyPayment
+             * @instance
+             */
+            MonthlyPayment.prototype.amount_utoken = "";
+    
+            /**
              * Encodes the specified MonthlyPayment message. Does not implicitly {@link main.MonthlyPayment.verify|verify} messages.
              * @function encode
              * @memberof main.MonthlyPayment
@@ -5118,6 +5127,8 @@
                     writer.uint32(/* id 8, wireType 2 =*/66).string(message.amount_market_ujpy);
                 if (message.amount_reward_ujpy != null && Object.hasOwnProperty.call(message, "amount_reward_ujpy"))
                     writer.uint32(/* id 9, wireType 2 =*/74).string(message.amount_reward_ujpy);
+                if (message.amount_utoken != null && Object.hasOwnProperty.call(message, "amount_utoken"))
+                    writer.uint32(/* id 10, wireType 2 =*/82).string(message.amount_utoken);
                 return writer;
             };
     
@@ -5178,6 +5189,9 @@
                         break;
                     case 9:
                         message.amount_reward_ujpy = reader.string();
+                        break;
+                    case 10:
+                        message.amount_utoken = reader.string();
                         break;
                     default:
                         reader.skipType(tag & 7);
@@ -5241,6 +5255,9 @@
                 if (message.amount_reward_ujpy != null && message.hasOwnProperty("amount_reward_ujpy"))
                     if (!$util.isString(message.amount_reward_ujpy))
                         return "amount_reward_ujpy: string expected";
+                if (message.amount_utoken != null && message.hasOwnProperty("amount_utoken"))
+                    if (!$util.isString(message.amount_utoken))
+                        return "amount_utoken: string expected";
                 return null;
             };
     
@@ -5274,6 +5291,8 @@
                     message.amount_market_ujpy = String(object.amount_market_ujpy);
                 if (object.amount_reward_ujpy != null)
                     message.amount_reward_ujpy = String(object.amount_reward_ujpy);
+                if (object.amount_utoken != null)
+                    message.amount_utoken = String(object.amount_utoken);
                 return message;
             };
     
@@ -5300,6 +5319,7 @@
                     object.amount_adjust_ujpy = "";
                     object.amount_market_ujpy = "";
                     object.amount_reward_ujpy = "";
+                    object.amount_utoken = "";
                 }
                 if (message.id != null && message.hasOwnProperty("id"))
                     object.id = message.id;
@@ -5319,6 +5339,8 @@
                     object.amount_market_ujpy = message.amount_market_ujpy;
                 if (message.amount_reward_ujpy != null && message.hasOwnProperty("amount_reward_ujpy"))
                     object.amount_reward_ujpy = message.amount_reward_ujpy;
+                if (message.amount_utoken != null && message.hasOwnProperty("amount_utoken"))
+                    object.amount_utoken = message.amount_utoken;
                 return object;
             };
     
@@ -5334,6 +5356,314 @@
             };
     
             return MonthlyPayment;
+        })();
+    
+        main.MonthlySettlement = (function() {
+    
+            /**
+             * Properties of a MonthlySettlement.
+             * @memberof main
+             * @interface IMonthlySettlement
+             * @property {string|null} [id] MonthlySettlement id
+             * @property {string|null} [year] MonthlySettlement year
+             * @property {string|null} [month] MonthlySettlement month
+             * @property {string|null} [reward_ujpy] MonthlySettlement reward_ujpy
+             * @property {string|null} [system_income_ujpy] MonthlySettlement system_income_ujpy
+             * @property {string|null} [purchase_utoken] MonthlySettlement purchase_utoken
+             * @property {string|null} [sale_utoken] MonthlySettlement sale_utoken
+             */
+    
+            /**
+             * Constructs a new MonthlySettlement.
+             * @memberof main
+             * @classdesc Represents a MonthlySettlement.
+             * @implements IMonthlySettlement
+             * @constructor
+             * @param {main.IMonthlySettlement=} [properties] Properties to set
+             */
+            function MonthlySettlement(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * MonthlySettlement id.
+             * @member {string} id
+             * @memberof main.MonthlySettlement
+             * @instance
+             */
+            MonthlySettlement.prototype.id = "";
+    
+            /**
+             * MonthlySettlement year.
+             * @member {string} year
+             * @memberof main.MonthlySettlement
+             * @instance
+             */
+            MonthlySettlement.prototype.year = "";
+    
+            /**
+             * MonthlySettlement month.
+             * @member {string} month
+             * @memberof main.MonthlySettlement
+             * @instance
+             */
+            MonthlySettlement.prototype.month = "";
+    
+            /**
+             * MonthlySettlement reward_ujpy.
+             * @member {string} reward_ujpy
+             * @memberof main.MonthlySettlement
+             * @instance
+             */
+            MonthlySettlement.prototype.reward_ujpy = "";
+    
+            /**
+             * MonthlySettlement system_income_ujpy.
+             * @member {string} system_income_ujpy
+             * @memberof main.MonthlySettlement
+             * @instance
+             */
+            MonthlySettlement.prototype.system_income_ujpy = "";
+    
+            /**
+             * MonthlySettlement purchase_utoken.
+             * @member {string} purchase_utoken
+             * @memberof main.MonthlySettlement
+             * @instance
+             */
+            MonthlySettlement.prototype.purchase_utoken = "";
+    
+            /**
+             * MonthlySettlement sale_utoken.
+             * @member {string} sale_utoken
+             * @memberof main.MonthlySettlement
+             * @instance
+             */
+            MonthlySettlement.prototype.sale_utoken = "";
+    
+            /**
+             * Encodes the specified MonthlySettlement message. Does not implicitly {@link main.MonthlySettlement.verify|verify} messages.
+             * @function encode
+             * @memberof main.MonthlySettlement
+             * @static
+             * @param {main.IMonthlySettlement} message MonthlySettlement message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            MonthlySettlement.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.year != null && Object.hasOwnProperty.call(message, "year"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.year);
+                if (message.month != null && Object.hasOwnProperty.call(message, "month"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.month);
+                if (message.reward_ujpy != null && Object.hasOwnProperty.call(message, "reward_ujpy"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.reward_ujpy);
+                if (message.system_income_ujpy != null && Object.hasOwnProperty.call(message, "system_income_ujpy"))
+                    writer.uint32(/* id 5, wireType 2 =*/42).string(message.system_income_ujpy);
+                if (message.purchase_utoken != null && Object.hasOwnProperty.call(message, "purchase_utoken"))
+                    writer.uint32(/* id 6, wireType 2 =*/50).string(message.purchase_utoken);
+                if (message.sale_utoken != null && Object.hasOwnProperty.call(message, "sale_utoken"))
+                    writer.uint32(/* id 7, wireType 2 =*/58).string(message.sale_utoken);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified MonthlySettlement message, length delimited. Does not implicitly {@link main.MonthlySettlement.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.MonthlySettlement
+             * @static
+             * @param {main.IMonthlySettlement} message MonthlySettlement message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            MonthlySettlement.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a MonthlySettlement message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.MonthlySettlement
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.MonthlySettlement} MonthlySettlement
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            MonthlySettlement.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.MonthlySettlement();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.year = reader.string();
+                        break;
+                    case 3:
+                        message.month = reader.string();
+                        break;
+                    case 4:
+                        message.reward_ujpy = reader.string();
+                        break;
+                    case 5:
+                        message.system_income_ujpy = reader.string();
+                        break;
+                    case 6:
+                        message.purchase_utoken = reader.string();
+                        break;
+                    case 7:
+                        message.sale_utoken = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a MonthlySettlement message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.MonthlySettlement
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.MonthlySettlement} MonthlySettlement
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            MonthlySettlement.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a MonthlySettlement message.
+             * @function verify
+             * @memberof main.MonthlySettlement
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            MonthlySettlement.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.year != null && message.hasOwnProperty("year"))
+                    if (!$util.isString(message.year))
+                        return "year: string expected";
+                if (message.month != null && message.hasOwnProperty("month"))
+                    if (!$util.isString(message.month))
+                        return "month: string expected";
+                if (message.reward_ujpy != null && message.hasOwnProperty("reward_ujpy"))
+                    if (!$util.isString(message.reward_ujpy))
+                        return "reward_ujpy: string expected";
+                if (message.system_income_ujpy != null && message.hasOwnProperty("system_income_ujpy"))
+                    if (!$util.isString(message.system_income_ujpy))
+                        return "system_income_ujpy: string expected";
+                if (message.purchase_utoken != null && message.hasOwnProperty("purchase_utoken"))
+                    if (!$util.isString(message.purchase_utoken))
+                        return "purchase_utoken: string expected";
+                if (message.sale_utoken != null && message.hasOwnProperty("sale_utoken"))
+                    if (!$util.isString(message.sale_utoken))
+                        return "sale_utoken: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a MonthlySettlement message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.MonthlySettlement
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.MonthlySettlement} MonthlySettlement
+             */
+            MonthlySettlement.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.MonthlySettlement)
+                    return object;
+                var message = new $root.main.MonthlySettlement();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.year != null)
+                    message.year = String(object.year);
+                if (object.month != null)
+                    message.month = String(object.month);
+                if (object.reward_ujpy != null)
+                    message.reward_ujpy = String(object.reward_ujpy);
+                if (object.system_income_ujpy != null)
+                    message.system_income_ujpy = String(object.system_income_ujpy);
+                if (object.purchase_utoken != null)
+                    message.purchase_utoken = String(object.purchase_utoken);
+                if (object.sale_utoken != null)
+                    message.sale_utoken = String(object.sale_utoken);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a MonthlySettlement message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.MonthlySettlement
+             * @static
+             * @param {main.MonthlySettlement} message MonthlySettlement
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            MonthlySettlement.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.year = "";
+                    object.month = "";
+                    object.reward_ujpy = "";
+                    object.system_income_ujpy = "";
+                    object.purchase_utoken = "";
+                    object.sale_utoken = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.year != null && message.hasOwnProperty("year"))
+                    object.year = message.year;
+                if (message.month != null && message.hasOwnProperty("month"))
+                    object.month = message.month;
+                if (message.reward_ujpy != null && message.hasOwnProperty("reward_ujpy"))
+                    object.reward_ujpy = message.reward_ujpy;
+                if (message.system_income_ujpy != null && message.hasOwnProperty("system_income_ujpy"))
+                    object.system_income_ujpy = message.system_income_ujpy;
+                if (message.purchase_utoken != null && message.hasOwnProperty("purchase_utoken"))
+                    object.purchase_utoken = message.purchase_utoken;
+                if (message.sale_utoken != null && message.hasOwnProperty("sale_utoken"))
+                    object.sale_utoken = message.sale_utoken;
+                return object;
+            };
+    
+            /**
+             * Converts this MonthlySettlement to JSON.
+             * @function toJSON
+             * @memberof main.MonthlySettlement
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            MonthlySettlement.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return MonthlySettlement;
         })();
     
         main.MonthlyUsage = (function() {
@@ -5798,6 +6128,292 @@
             return NormalAskDelete;
         })();
     
+        main.NormalBidHistory = (function() {
+    
+            /**
+             * Properties of a NormalBidHistory.
+             * @memberof main
+             * @interface INormalBidHistory
+             * @property {string|null} [id] NormalBidHistory id
+             * @property {string|null} [account_id] NormalBidHistory account_id
+             * @property {string|null} [price_ujpy] NormalBidHistory price_ujpy
+             * @property {string|null} [amount_uupx] NormalBidHistory amount_uupx
+             * @property {boolean|null} [is_accepted] NormalBidHistory is_accepted
+             * @property {string|null} [contract_price_ujpy] NormalBidHistory contract_price_ujpy
+             */
+    
+            /**
+             * Constructs a new NormalBidHistory.
+             * @memberof main
+             * @classdesc Represents a NormalBidHistory.
+             * @implements INormalBidHistory
+             * @constructor
+             * @param {main.INormalBidHistory=} [properties] Properties to set
+             */
+            function NormalBidHistory(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * NormalBidHistory id.
+             * @member {string} id
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.id = "";
+    
+            /**
+             * NormalBidHistory account_id.
+             * @member {string} account_id
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.account_id = "";
+    
+            /**
+             * NormalBidHistory price_ujpy.
+             * @member {string} price_ujpy
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.price_ujpy = "";
+    
+            /**
+             * NormalBidHistory amount_uupx.
+             * @member {string} amount_uupx
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.amount_uupx = "";
+    
+            /**
+             * NormalBidHistory is_accepted.
+             * @member {boolean} is_accepted
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.is_accepted = false;
+    
+            /**
+             * NormalBidHistory contract_price_ujpy.
+             * @member {string} contract_price_ujpy
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.contract_price_ujpy = "";
+    
+            /**
+             * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+             * @function encode
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            NormalBidHistory.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.account_id != null && Object.hasOwnProperty.call(message, "account_id"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.account_id);
+                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.price_ujpy);
+                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uupx);
+                if (message.is_accepted != null && Object.hasOwnProperty.call(message, "is_accepted"))
+                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.is_accepted);
+                if (message.contract_price_ujpy != null && Object.hasOwnProperty.call(message, "contract_price_ujpy"))
+                    writer.uint32(/* id 6, wireType 2 =*/50).string(message.contract_price_ujpy);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            NormalBidHistory.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a NormalBidHistory message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.NormalBidHistory} NormalBidHistory
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            NormalBidHistory.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalBidHistory();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.account_id = reader.string();
+                        break;
+                    case 3:
+                        message.price_ujpy = reader.string();
+                        break;
+                    case 4:
+                        message.amount_uupx = reader.string();
+                        break;
+                    case 5:
+                        message.is_accepted = reader.bool();
+                        break;
+                    case 6:
+                        message.contract_price_ujpy = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.NormalBidHistory} NormalBidHistory
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            NormalBidHistory.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a NormalBidHistory message.
+             * @function verify
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            NormalBidHistory.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.account_id != null && message.hasOwnProperty("account_id"))
+                    if (!$util.isString(message.account_id))
+                        return "account_id: string expected";
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    if (!$util.isString(message.price_ujpy))
+                        return "price_ujpy: string expected";
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    if (!$util.isString(message.amount_uupx))
+                        return "amount_uupx: string expected";
+                if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
+                    if (typeof message.is_accepted !== "boolean")
+                        return "is_accepted: boolean expected";
+                if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
+                    if (!$util.isString(message.contract_price_ujpy))
+                        return "contract_price_ujpy: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.NormalBidHistory} NormalBidHistory
+             */
+            NormalBidHistory.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.NormalBidHistory)
+                    return object;
+                var message = new $root.main.NormalBidHistory();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.account_id != null)
+                    message.account_id = String(object.account_id);
+                if (object.price_ujpy != null)
+                    message.price_ujpy = String(object.price_ujpy);
+                if (object.amount_uupx != null)
+                    message.amount_uupx = String(object.amount_uupx);
+                if (object.is_accepted != null)
+                    message.is_accepted = Boolean(object.is_accepted);
+                if (object.contract_price_ujpy != null)
+                    message.contract_price_ujpy = String(object.contract_price_ujpy);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {main.NormalBidHistory} message NormalBidHistory
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            NormalBidHistory.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.account_id = "";
+                    object.price_ujpy = "";
+                    object.amount_uupx = "";
+                    object.is_accepted = false;
+                    object.contract_price_ujpy = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.account_id != null && message.hasOwnProperty("account_id"))
+                    object.account_id = message.account_id;
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    object.price_ujpy = message.price_ujpy;
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    object.amount_uupx = message.amount_uupx;
+                if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
+                    object.is_accepted = message.is_accepted;
+                if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
+                    object.contract_price_ujpy = message.contract_price_ujpy;
+                return object;
+            };
+    
+            /**
+             * Converts this NormalBidHistory to JSON.
+             * @function toJSON
+             * @memberof main.NormalBidHistory
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            NormalBidHistory.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return NormalBidHistory;
+        })();
+    
         /**
          * NormalAskHistoryType enum.
          * @name main.NormalAskHistoryType
@@ -6140,6 +6756,270 @@
             return NormalAskHistory;
         })();
     
+        main.NormalAskSetting = (function() {
+    
+            /**
+             * Properties of a NormalAskSetting.
+             * @memberof main
+             * @interface INormalAskSetting
+             * @property {string|null} [id] NormalAskSetting id
+             * @property {string|null} [price_ujpy] NormalAskSetting price_ujpy
+             * @property {string|null} [amount_uupx] NormalAskSetting amount_uupx
+             * @property {string|null} [ratio_percentage] NormalAskSetting ratio_percentage
+             * @property {boolean|null} [enable] NormalAskSetting enable
+             */
+    
+            /**
+             * Constructs a new NormalAskSetting.
+             * @memberof main
+             * @classdesc Represents a NormalAskSetting.
+             * @implements INormalAskSetting
+             * @constructor
+             * @param {main.INormalAskSetting=} [properties] Properties to set
+             */
+            function NormalAskSetting(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * NormalAskSetting id.
+             * @member {string} id
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.id = "";
+    
+            /**
+             * NormalAskSetting price_ujpy.
+             * @member {string} price_ujpy
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.price_ujpy = "";
+    
+            /**
+             * NormalAskSetting amount_uupx.
+             * @member {string} amount_uupx
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.amount_uupx = "";
+    
+            /**
+             * NormalAskSetting ratio_percentage.
+             * @member {string} ratio_percentage
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.ratio_percentage = "";
+    
+            /**
+             * NormalAskSetting enable.
+             * @member {boolean} enable
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.enable = false;
+    
+            /**
+             * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+             * @function encode
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            NormalAskSetting.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
+                if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.ratio_percentage);
+                if (message.enable != null && Object.hasOwnProperty.call(message, "enable"))
+                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.enable);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            NormalAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a NormalAskSetting message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.NormalAskSetting} NormalAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            NormalAskSetting.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalAskSetting();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.price_ujpy = reader.string();
+                        break;
+                    case 3:
+                        message.amount_uupx = reader.string();
+                        break;
+                    case 4:
+                        message.ratio_percentage = reader.string();
+                        break;
+                    case 5:
+                        message.enable = reader.bool();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.NormalAskSetting} NormalAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            NormalAskSetting.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a NormalAskSetting message.
+             * @function verify
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            NormalAskSetting.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    if (!$util.isString(message.price_ujpy))
+                        return "price_ujpy: string expected";
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    if (!$util.isString(message.amount_uupx))
+                        return "amount_uupx: string expected";
+                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                    if (!$util.isString(message.ratio_percentage))
+                        return "ratio_percentage: string expected";
+                if (message.enable != null && message.hasOwnProperty("enable"))
+                    if (typeof message.enable !== "boolean")
+                        return "enable: boolean expected";
+                return null;
+            };
+    
+            /**
+             * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.NormalAskSetting} NormalAskSetting
+             */
+            NormalAskSetting.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.NormalAskSetting)
+                    return object;
+                var message = new $root.main.NormalAskSetting();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.price_ujpy != null)
+                    message.price_ujpy = String(object.price_ujpy);
+                if (object.amount_uupx != null)
+                    message.amount_uupx = String(object.amount_uupx);
+                if (object.ratio_percentage != null)
+                    message.ratio_percentage = String(object.ratio_percentage);
+                if (object.enable != null)
+                    message.enable = Boolean(object.enable);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {main.NormalAskSetting} message NormalAskSetting
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            NormalAskSetting.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.price_ujpy = "";
+                    object.amount_uupx = "";
+                    object.ratio_percentage = "";
+                    object.enable = false;
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    object.price_ujpy = message.price_ujpy;
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    object.amount_uupx = message.amount_uupx;
+                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                    object.ratio_percentage = message.ratio_percentage;
+                if (message.enable != null && message.hasOwnProperty("enable"))
+                    object.enable = message.enable;
+                return object;
+            };
+    
+            /**
+             * Converts this NormalAskSetting to JSON.
+             * @function toJSON
+             * @memberof main.NormalAskSetting
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            NormalAskSetting.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return NormalAskSetting;
+        })();
+    
         /**
          * NormalAskType enum.
          * @name main.NormalAskType
@@ -6460,270 +7340,6 @@
             return NormalAsk;
         })();
     
-        main.NormalAskSetting = (function() {
-    
-            /**
-             * Properties of a NormalAskSetting.
-             * @memberof main
-             * @interface INormalAskSetting
-             * @property {string|null} [id] NormalAskSetting id
-             * @property {string|null} [price_ujpy] NormalAskSetting price_ujpy
-             * @property {string|null} [amount_uupx] NormalAskSetting amount_uupx
-             * @property {string|null} [ratio_percentage] NormalAskSetting ratio_percentage
-             * @property {boolean|null} [enable] NormalAskSetting enable
-             */
-    
-            /**
-             * Constructs a new NormalAskSetting.
-             * @memberof main
-             * @classdesc Represents a NormalAskSetting.
-             * @implements INormalAskSetting
-             * @constructor
-             * @param {main.INormalAskSetting=} [properties] Properties to set
-             */
-            function NormalAskSetting(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * NormalAskSetting id.
-             * @member {string} id
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.id = "";
-    
-            /**
-             * NormalAskSetting price_ujpy.
-             * @member {string} price_ujpy
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.price_ujpy = "";
-    
-            /**
-             * NormalAskSetting amount_uupx.
-             * @member {string} amount_uupx
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.amount_uupx = "";
-    
-            /**
-             * NormalAskSetting ratio_percentage.
-             * @member {string} ratio_percentage
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.ratio_percentage = "";
-    
-            /**
-             * NormalAskSetting enable.
-             * @member {boolean} enable
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.enable = false;
-    
-            /**
-             * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-             * @function encode
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            NormalAskSetting.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
-                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
-                if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.ratio_percentage);
-                if (message.enable != null && Object.hasOwnProperty.call(message, "enable"))
-                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.enable);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            NormalAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a NormalAskSetting message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.NormalAskSetting} NormalAskSetting
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            NormalAskSetting.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalAskSetting();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.price_ujpy = reader.string();
-                        break;
-                    case 3:
-                        message.amount_uupx = reader.string();
-                        break;
-                    case 4:
-                        message.ratio_percentage = reader.string();
-                        break;
-                    case 5:
-                        message.enable = reader.bool();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.NormalAskSetting} NormalAskSetting
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            NormalAskSetting.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a NormalAskSetting message.
-             * @function verify
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            NormalAskSetting.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    if (!$util.isString(message.price_ujpy))
-                        return "price_ujpy: string expected";
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    if (!$util.isString(message.amount_uupx))
-                        return "amount_uupx: string expected";
-                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
-                    if (!$util.isString(message.ratio_percentage))
-                        return "ratio_percentage: string expected";
-                if (message.enable != null && message.hasOwnProperty("enable"))
-                    if (typeof message.enable !== "boolean")
-                        return "enable: boolean expected";
-                return null;
-            };
-    
-            /**
-             * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.NormalAskSetting} NormalAskSetting
-             */
-            NormalAskSetting.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.NormalAskSetting)
-                    return object;
-                var message = new $root.main.NormalAskSetting();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.price_ujpy != null)
-                    message.price_ujpy = String(object.price_ujpy);
-                if (object.amount_uupx != null)
-                    message.amount_uupx = String(object.amount_uupx);
-                if (object.ratio_percentage != null)
-                    message.ratio_percentage = String(object.ratio_percentage);
-                if (object.enable != null)
-                    message.enable = Boolean(object.enable);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {main.NormalAskSetting} message NormalAskSetting
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            NormalAskSetting.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.price_ujpy = "";
-                    object.amount_uupx = "";
-                    object.ratio_percentage = "";
-                    object.enable = false;
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    object.price_ujpy = message.price_ujpy;
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    object.amount_uupx = message.amount_uupx;
-                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
-                    object.ratio_percentage = message.ratio_percentage;
-                if (message.enable != null && message.hasOwnProperty("enable"))
-                    object.enable = message.enable;
-                return object;
-            };
-    
-            /**
-             * Converts this NormalAskSetting to JSON.
-             * @function toJSON
-             * @memberof main.NormalAskSetting
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            NormalAskSetting.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return NormalAskSetting;
-        })();
-    
         main.NormalBidDelete = (function() {
     
             /**
@@ -6920,292 +7536,6 @@
             };
     
             return NormalBidDelete;
-        })();
-    
-        main.NormalBidHistory = (function() {
-    
-            /**
-             * Properties of a NormalBidHistory.
-             * @memberof main
-             * @interface INormalBidHistory
-             * @property {string|null} [id] NormalBidHistory id
-             * @property {string|null} [account_id] NormalBidHistory account_id
-             * @property {string|null} [price_ujpy] NormalBidHistory price_ujpy
-             * @property {string|null} [amount_uupx] NormalBidHistory amount_uupx
-             * @property {boolean|null} [is_accepted] NormalBidHistory is_accepted
-             * @property {string|null} [contract_price_ujpy] NormalBidHistory contract_price_ujpy
-             */
-    
-            /**
-             * Constructs a new NormalBidHistory.
-             * @memberof main
-             * @classdesc Represents a NormalBidHistory.
-             * @implements INormalBidHistory
-             * @constructor
-             * @param {main.INormalBidHistory=} [properties] Properties to set
-             */
-            function NormalBidHistory(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * NormalBidHistory id.
-             * @member {string} id
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.id = "";
-    
-            /**
-             * NormalBidHistory account_id.
-             * @member {string} account_id
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.account_id = "";
-    
-            /**
-             * NormalBidHistory price_ujpy.
-             * @member {string} price_ujpy
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.price_ujpy = "";
-    
-            /**
-             * NormalBidHistory amount_uupx.
-             * @member {string} amount_uupx
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.amount_uupx = "";
-    
-            /**
-             * NormalBidHistory is_accepted.
-             * @member {boolean} is_accepted
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.is_accepted = false;
-    
-            /**
-             * NormalBidHistory contract_price_ujpy.
-             * @member {string} contract_price_ujpy
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.contract_price_ujpy = "";
-    
-            /**
-             * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-             * @function encode
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            NormalBidHistory.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.account_id != null && Object.hasOwnProperty.call(message, "account_id"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.account_id);
-                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.price_ujpy);
-                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uupx);
-                if (message.is_accepted != null && Object.hasOwnProperty.call(message, "is_accepted"))
-                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.is_accepted);
-                if (message.contract_price_ujpy != null && Object.hasOwnProperty.call(message, "contract_price_ujpy"))
-                    writer.uint32(/* id 6, wireType 2 =*/50).string(message.contract_price_ujpy);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            NormalBidHistory.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a NormalBidHistory message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.NormalBidHistory} NormalBidHistory
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            NormalBidHistory.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalBidHistory();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.account_id = reader.string();
-                        break;
-                    case 3:
-                        message.price_ujpy = reader.string();
-                        break;
-                    case 4:
-                        message.amount_uupx = reader.string();
-                        break;
-                    case 5:
-                        message.is_accepted = reader.bool();
-                        break;
-                    case 6:
-                        message.contract_price_ujpy = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.NormalBidHistory} NormalBidHistory
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            NormalBidHistory.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a NormalBidHistory message.
-             * @function verify
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            NormalBidHistory.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.account_id != null && message.hasOwnProperty("account_id"))
-                    if (!$util.isString(message.account_id))
-                        return "account_id: string expected";
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    if (!$util.isString(message.price_ujpy))
-                        return "price_ujpy: string expected";
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    if (!$util.isString(message.amount_uupx))
-                        return "amount_uupx: string expected";
-                if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
-                    if (typeof message.is_accepted !== "boolean")
-                        return "is_accepted: boolean expected";
-                if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
-                    if (!$util.isString(message.contract_price_ujpy))
-                        return "contract_price_ujpy: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.NormalBidHistory} NormalBidHistory
-             */
-            NormalBidHistory.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.NormalBidHistory)
-                    return object;
-                var message = new $root.main.NormalBidHistory();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.account_id != null)
-                    message.account_id = String(object.account_id);
-                if (object.price_ujpy != null)
-                    message.price_ujpy = String(object.price_ujpy);
-                if (object.amount_uupx != null)
-                    message.amount_uupx = String(object.amount_uupx);
-                if (object.is_accepted != null)
-                    message.is_accepted = Boolean(object.is_accepted);
-                if (object.contract_price_ujpy != null)
-                    message.contract_price_ujpy = String(object.contract_price_ujpy);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {main.NormalBidHistory} message NormalBidHistory
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            NormalBidHistory.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.account_id = "";
-                    object.price_ujpy = "";
-                    object.amount_uupx = "";
-                    object.is_accepted = false;
-                    object.contract_price_ujpy = "";
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.account_id != null && message.hasOwnProperty("account_id"))
-                    object.account_id = message.account_id;
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    object.price_ujpy = message.price_ujpy;
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    object.amount_uupx = message.amount_uupx;
-                if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
-                    object.is_accepted = message.is_accepted;
-                if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
-                    object.contract_price_ujpy = message.contract_price_ujpy;
-                return object;
-            };
-    
-            /**
-             * Converts this NormalBidHistory to JSON.
-             * @function toJSON
-             * @memberof main.NormalBidHistory
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            NormalBidHistory.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return NormalBidHistory;
         })();
     
         main.NormalBid = (function() {
@@ -8760,6 +9090,226 @@
             return RenewableAskHistory;
         })();
     
+        main.RenewableAskSetting = (function() {
+    
+            /**
+             * Properties of a RenewableAskSetting.
+             * @memberof main
+             * @interface IRenewableAskSetting
+             * @property {string|null} [id] RenewableAskSetting id
+             * @property {string|null} [price_ujpy] RenewableAskSetting price_ujpy
+             * @property {string|null} [amount_uspx] RenewableAskSetting amount_uspx
+             */
+    
+            /**
+             * Constructs a new RenewableAskSetting.
+             * @memberof main
+             * @classdesc Represents a RenewableAskSetting.
+             * @implements IRenewableAskSetting
+             * @constructor
+             * @param {main.IRenewableAskSetting=} [properties] Properties to set
+             */
+            function RenewableAskSetting(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * RenewableAskSetting id.
+             * @member {string} id
+             * @memberof main.RenewableAskSetting
+             * @instance
+             */
+            RenewableAskSetting.prototype.id = "";
+    
+            /**
+             * RenewableAskSetting price_ujpy.
+             * @member {string} price_ujpy
+             * @memberof main.RenewableAskSetting
+             * @instance
+             */
+            RenewableAskSetting.prototype.price_ujpy = "";
+    
+            /**
+             * RenewableAskSetting amount_uspx.
+             * @member {string} amount_uspx
+             * @memberof main.RenewableAskSetting
+             * @instance
+             */
+            RenewableAskSetting.prototype.amount_uspx = "";
+    
+            /**
+             * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+             * @function encode
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            RenewableAskSetting.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+                if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            RenewableAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a RenewableAskSetting message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.RenewableAskSetting} RenewableAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            RenewableAskSetting.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.RenewableAskSetting();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.price_ujpy = reader.string();
+                        break;
+                    case 3:
+                        message.amount_uspx = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.RenewableAskSetting} RenewableAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            RenewableAskSetting.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a RenewableAskSetting message.
+             * @function verify
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            RenewableAskSetting.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    if (!$util.isString(message.price_ujpy))
+                        return "price_ujpy: string expected";
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    if (!$util.isString(message.amount_uspx))
+                        return "amount_uspx: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.RenewableAskSetting} RenewableAskSetting
+             */
+            RenewableAskSetting.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.RenewableAskSetting)
+                    return object;
+                var message = new $root.main.RenewableAskSetting();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.price_ujpy != null)
+                    message.price_ujpy = String(object.price_ujpy);
+                if (object.amount_uspx != null)
+                    message.amount_uspx = String(object.amount_uspx);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {main.RenewableAskSetting} message RenewableAskSetting
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            RenewableAskSetting.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.price_ujpy = "";
+                    object.amount_uspx = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    object.price_ujpy = message.price_ujpy;
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    object.amount_uspx = message.amount_uspx;
+                return object;
+            };
+    
+            /**
+             * Converts this RenewableAskSetting to JSON.
+             * @function toJSON
+             * @memberof main.RenewableAskSetting
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            RenewableAskSetting.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return RenewableAskSetting;
+        })();
+    
         /**
          * RenewableAskType enum.
          * @name main.RenewableAskType
@@ -9078,226 +9628,6 @@
             };
     
             return RenewableAsk;
-        })();
-    
-        main.RenewableAskSetting = (function() {
-    
-            /**
-             * Properties of a RenewableAskSetting.
-             * @memberof main
-             * @interface IRenewableAskSetting
-             * @property {string|null} [id] RenewableAskSetting id
-             * @property {string|null} [price_ujpy] RenewableAskSetting price_ujpy
-             * @property {string|null} [amount_uspx] RenewableAskSetting amount_uspx
-             */
-    
-            /**
-             * Constructs a new RenewableAskSetting.
-             * @memberof main
-             * @classdesc Represents a RenewableAskSetting.
-             * @implements IRenewableAskSetting
-             * @constructor
-             * @param {main.IRenewableAskSetting=} [properties] Properties to set
-             */
-            function RenewableAskSetting(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * RenewableAskSetting id.
-             * @member {string} id
-             * @memberof main.RenewableAskSetting
-             * @instance
-             */
-            RenewableAskSetting.prototype.id = "";
-    
-            /**
-             * RenewableAskSetting price_ujpy.
-             * @member {string} price_ujpy
-             * @memberof main.RenewableAskSetting
-             * @instance
-             */
-            RenewableAskSetting.prototype.price_ujpy = "";
-    
-            /**
-             * RenewableAskSetting amount_uspx.
-             * @member {string} amount_uspx
-             * @memberof main.RenewableAskSetting
-             * @instance
-             */
-            RenewableAskSetting.prototype.amount_uspx = "";
-    
-            /**
-             * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-             * @function encode
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            RenewableAskSetting.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
-                if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            RenewableAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a RenewableAskSetting message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.RenewableAskSetting} RenewableAskSetting
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            RenewableAskSetting.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.RenewableAskSetting();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.price_ujpy = reader.string();
-                        break;
-                    case 3:
-                        message.amount_uspx = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.RenewableAskSetting} RenewableAskSetting
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            RenewableAskSetting.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a RenewableAskSetting message.
-             * @function verify
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            RenewableAskSetting.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    if (!$util.isString(message.price_ujpy))
-                        return "price_ujpy: string expected";
-                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                    if (!$util.isString(message.amount_uspx))
-                        return "amount_uspx: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.RenewableAskSetting} RenewableAskSetting
-             */
-            RenewableAskSetting.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.RenewableAskSetting)
-                    return object;
-                var message = new $root.main.RenewableAskSetting();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.price_ujpy != null)
-                    message.price_ujpy = String(object.price_ujpy);
-                if (object.amount_uspx != null)
-                    message.amount_uspx = String(object.amount_uspx);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {main.RenewableAskSetting} message RenewableAskSetting
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            RenewableAskSetting.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.price_ujpy = "";
-                    object.amount_uspx = "";
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    object.price_ujpy = message.price_ujpy;
-                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                    object.amount_uspx = message.amount_uspx;
-                return object;
-            };
-    
-            /**
-             * Converts this RenewableAskSetting to JSON.
-             * @function toJSON
-             * @memberof main.RenewableAskSetting
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            RenewableAskSetting.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return RenewableAskSetting;
         })();
     
         main.RenewableBidDelete = (function() {

--- a/common/src/proto.d.ts
+++ b/common/src/proto.d.ts
@@ -2,101 +2,6 @@ import * as $protobuf from "protobufjs";
 /** Namespace main. */
 export namespace main {
 
-    /** Properties of an AccountantAccount. */
-    interface IAccountantAccount {
-
-        /** AccountantAccount id */
-        id?: (string|null);
-
-        /** AccountantAccount name */
-        name?: (string|null);
-
-        /** AccountantAccount xrp_address */
-        xrp_address?: (string|null);
-    }
-
-    /** Represents an AccountantAccount. */
-    class AccountantAccount implements IAccountantAccount {
-
-        /**
-         * Constructs a new AccountantAccount.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.IAccountantAccount);
-
-        /** AccountantAccount id. */
-        public id: string;
-
-        /** AccountantAccount name. */
-        public name: string;
-
-        /** AccountantAccount xrp_address. */
-        public xrp_address: string;
-
-        /**
-         * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-         * @param message AccountantAccount message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.IAccountantAccount, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-         * @param message AccountantAccount message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.IAccountantAccount, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes an AccountantAccount message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns AccountantAccount
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.AccountantAccount;
-
-        /**
-         * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns AccountantAccount
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.AccountantAccount;
-
-        /**
-         * Verifies an AccountantAccount message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns AccountantAccount
-         */
-        public static fromObject(object: { [k: string]: any }): main.AccountantAccount;
-
-        /**
-         * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
-         * @param message AccountantAccount
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.AccountantAccount, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this AccountantAccount to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
     /** Properties of an AccountPrivate. */
     interface IAccountPrivate {
 
@@ -193,6 +98,101 @@ export namespace main {
 
         /**
          * Converts this AccountPrivate to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of an AccountantAccount. */
+    interface IAccountantAccount {
+
+        /** AccountantAccount id */
+        id?: (string|null);
+
+        /** AccountantAccount name */
+        name?: (string|null);
+
+        /** AccountantAccount xrp_address */
+        xrp_address?: (string|null);
+    }
+
+    /** Represents an AccountantAccount. */
+    class AccountantAccount implements IAccountantAccount {
+
+        /**
+         * Constructs a new AccountantAccount.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.IAccountantAccount);
+
+        /** AccountantAccount id. */
+        public id: string;
+
+        /** AccountantAccount name. */
+        public name: string;
+
+        /** AccountantAccount xrp_address. */
+        public xrp_address: string;
+
+        /**
+         * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+         * @param message AccountantAccount message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.IAccountantAccount, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+         * @param message AccountantAccount message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.IAccountantAccount, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes an AccountantAccount message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns AccountantAccount
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.AccountantAccount;
+
+        /**
+         * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns AccountantAccount
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.AccountantAccount;
+
+        /**
+         * Verifies an AccountantAccount message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns AccountantAccount
+         */
+        public static fromObject(object: { [k: string]: any }): main.AccountantAccount;
+
+        /**
+         * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
+         * @param message AccountantAccount
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.AccountantAccount, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this AccountantAccount to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
@@ -622,107 +622,6 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a Balance. */
-    interface IBalance {
-
-        /** Balance id */
-        id?: (string|null);
-
-        /** Balance student_account_id */
-        student_account_id?: (string|null);
-
-        /** Balance amount_uupx */
-        amount_uupx?: (string|null);
-
-        /** Balance amount_uspx */
-        amount_uspx?: (string|null);
-    }
-
-    /** Represents a Balance. */
-    class Balance implements IBalance {
-
-        /**
-         * Constructs a new Balance.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.IBalance);
-
-        /** Balance id. */
-        public id: string;
-
-        /** Balance student_account_id. */
-        public student_account_id: string;
-
-        /** Balance amount_uupx. */
-        public amount_uupx: string;
-
-        /** Balance amount_uspx. */
-        public amount_uspx: string;
-
-        /**
-         * Encodes the specified Balance message. Does not implicitly {@link main.Balance.verify|verify} messages.
-         * @param message Balance message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.IBalance, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified Balance message, length delimited. Does not implicitly {@link main.Balance.verify|verify} messages.
-         * @param message Balance message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.IBalance, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a Balance message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns Balance
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.Balance;
-
-        /**
-         * Decodes a Balance message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns Balance
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.Balance;
-
-        /**
-         * Verifies a Balance message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a Balance message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns Balance
-         */
-        public static fromObject(object: { [k: string]: any }): main.Balance;
-
-        /**
-         * Creates a plain object from a Balance message. Also converts values to other types if specified.
-         * @param message Balance
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.Balance, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this Balance to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
     /** Properties of a BalanceSnapshot. */
     interface IBalanceSnapshot {
 
@@ -819,6 +718,107 @@ export namespace main {
 
         /**
          * Converts this BalanceSnapshot to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a Balance. */
+    interface IBalance {
+
+        /** Balance id */
+        id?: (string|null);
+
+        /** Balance student_account_id */
+        student_account_id?: (string|null);
+
+        /** Balance amount_uupx */
+        amount_uupx?: (string|null);
+
+        /** Balance amount_uspx */
+        amount_uspx?: (string|null);
+    }
+
+    /** Represents a Balance. */
+    class Balance implements IBalance {
+
+        /**
+         * Constructs a new Balance.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.IBalance);
+
+        /** Balance id. */
+        public id: string;
+
+        /** Balance student_account_id. */
+        public student_account_id: string;
+
+        /** Balance amount_uupx. */
+        public amount_uupx: string;
+
+        /** Balance amount_uspx. */
+        public amount_uspx: string;
+
+        /**
+         * Encodes the specified Balance message. Does not implicitly {@link main.Balance.verify|verify} messages.
+         * @param message Balance message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.IBalance, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified Balance message, length delimited. Does not implicitly {@link main.Balance.verify|verify} messages.
+         * @param message Balance message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.IBalance, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a Balance message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns Balance
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.Balance;
+
+        /**
+         * Decodes a Balance message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns Balance
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.Balance;
+
+        /**
+         * Verifies a Balance message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a Balance message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns Balance
+         */
+        public static fromObject(object: { [k: string]: any }): main.Balance;
+
+        /**
+         * Creates a plain object from a Balance message. Also converts values to other types if specified.
+         * @param message Balance
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.Balance, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this Balance to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
@@ -2071,6 +2071,9 @@ export namespace main {
 
         /** MonthlyPayment amount_reward_ujpy */
         amount_reward_ujpy?: (string|null);
+
+        /** MonthlyPayment amount_utoken */
+        amount_utoken?: (string|null);
     }
 
     /** Represents a MonthlyPayment. */
@@ -2108,6 +2111,9 @@ export namespace main {
 
         /** MonthlyPayment amount_reward_ujpy. */
         public amount_reward_ujpy: string;
+
+        /** MonthlyPayment amount_utoken. */
+        public amount_utoken: string;
 
         /**
          * Encodes the specified MonthlyPayment message. Does not implicitly {@link main.MonthlyPayment.verify|verify} messages.
@@ -2168,6 +2174,125 @@ export namespace main {
 
         /**
          * Converts this MonthlyPayment to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a MonthlySettlement. */
+    interface IMonthlySettlement {
+
+        /** MonthlySettlement id */
+        id?: (string|null);
+
+        /** MonthlySettlement year */
+        year?: (string|null);
+
+        /** MonthlySettlement month */
+        month?: (string|null);
+
+        /** MonthlySettlement reward_ujpy */
+        reward_ujpy?: (string|null);
+
+        /** MonthlySettlement system_income_ujpy */
+        system_income_ujpy?: (string|null);
+
+        /** MonthlySettlement purchase_utoken */
+        purchase_utoken?: (string|null);
+
+        /** MonthlySettlement sale_utoken */
+        sale_utoken?: (string|null);
+    }
+
+    /** Represents a MonthlySettlement. */
+    class MonthlySettlement implements IMonthlySettlement {
+
+        /**
+         * Constructs a new MonthlySettlement.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.IMonthlySettlement);
+
+        /** MonthlySettlement id. */
+        public id: string;
+
+        /** MonthlySettlement year. */
+        public year: string;
+
+        /** MonthlySettlement month. */
+        public month: string;
+
+        /** MonthlySettlement reward_ujpy. */
+        public reward_ujpy: string;
+
+        /** MonthlySettlement system_income_ujpy. */
+        public system_income_ujpy: string;
+
+        /** MonthlySettlement purchase_utoken. */
+        public purchase_utoken: string;
+
+        /** MonthlySettlement sale_utoken. */
+        public sale_utoken: string;
+
+        /**
+         * Encodes the specified MonthlySettlement message. Does not implicitly {@link main.MonthlySettlement.verify|verify} messages.
+         * @param message MonthlySettlement message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.IMonthlySettlement, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified MonthlySettlement message, length delimited. Does not implicitly {@link main.MonthlySettlement.verify|verify} messages.
+         * @param message MonthlySettlement message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.IMonthlySettlement, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a MonthlySettlement message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns MonthlySettlement
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.MonthlySettlement;
+
+        /**
+         * Decodes a MonthlySettlement message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns MonthlySettlement
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.MonthlySettlement;
+
+        /**
+         * Verifies a MonthlySettlement message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a MonthlySettlement message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns MonthlySettlement
+         */
+        public static fromObject(object: { [k: string]: any }): main.MonthlySettlement;
+
+        /**
+         * Creates a plain object from a MonthlySettlement message. Also converts values to other types if specified.
+         * @param message MonthlySettlement
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.MonthlySettlement, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this MonthlySettlement to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
@@ -2369,6 +2494,119 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
+    /** Properties of a NormalBidHistory. */
+    interface INormalBidHistory {
+
+        /** NormalBidHistory id */
+        id?: (string|null);
+
+        /** NormalBidHistory account_id */
+        account_id?: (string|null);
+
+        /** NormalBidHistory price_ujpy */
+        price_ujpy?: (string|null);
+
+        /** NormalBidHistory amount_uupx */
+        amount_uupx?: (string|null);
+
+        /** NormalBidHistory is_accepted */
+        is_accepted?: (boolean|null);
+
+        /** NormalBidHistory contract_price_ujpy */
+        contract_price_ujpy?: (string|null);
+    }
+
+    /** Represents a NormalBidHistory. */
+    class NormalBidHistory implements INormalBidHistory {
+
+        /**
+         * Constructs a new NormalBidHistory.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.INormalBidHistory);
+
+        /** NormalBidHistory id. */
+        public id: string;
+
+        /** NormalBidHistory account_id. */
+        public account_id: string;
+
+        /** NormalBidHistory price_ujpy. */
+        public price_ujpy: string;
+
+        /** NormalBidHistory amount_uupx. */
+        public amount_uupx: string;
+
+        /** NormalBidHistory is_accepted. */
+        public is_accepted: boolean;
+
+        /** NormalBidHistory contract_price_ujpy. */
+        public contract_price_ujpy: string;
+
+        /**
+         * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+         * @param message NormalBidHistory message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.INormalBidHistory, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+         * @param message NormalBidHistory message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.INormalBidHistory, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a NormalBidHistory message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns NormalBidHistory
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.NormalBidHistory;
+
+        /**
+         * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns NormalBidHistory
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.NormalBidHistory;
+
+        /**
+         * Verifies a NormalBidHistory message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns NormalBidHistory
+         */
+        public static fromObject(object: { [k: string]: any }): main.NormalBidHistory;
+
+        /**
+         * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
+         * @param message NormalBidHistory
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.NormalBidHistory, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this NormalBidHistory to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
     /** NormalAskHistoryType enum. */
     enum NormalAskHistoryType {
         UNKNOWN = 0,
@@ -2495,6 +2733,113 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
+    /** Properties of a NormalAskSetting. */
+    interface INormalAskSetting {
+
+        /** NormalAskSetting id */
+        id?: (string|null);
+
+        /** NormalAskSetting price_ujpy */
+        price_ujpy?: (string|null);
+
+        /** NormalAskSetting amount_uupx */
+        amount_uupx?: (string|null);
+
+        /** NormalAskSetting ratio_percentage */
+        ratio_percentage?: (string|null);
+
+        /** NormalAskSetting enable */
+        enable?: (boolean|null);
+    }
+
+    /** Represents a NormalAskSetting. */
+    class NormalAskSetting implements INormalAskSetting {
+
+        /**
+         * Constructs a new NormalAskSetting.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.INormalAskSetting);
+
+        /** NormalAskSetting id. */
+        public id: string;
+
+        /** NormalAskSetting price_ujpy. */
+        public price_ujpy: string;
+
+        /** NormalAskSetting amount_uupx. */
+        public amount_uupx: string;
+
+        /** NormalAskSetting ratio_percentage. */
+        public ratio_percentage: string;
+
+        /** NormalAskSetting enable. */
+        public enable: boolean;
+
+        /**
+         * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+         * @param message NormalAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.INormalAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+         * @param message NormalAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.INormalAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a NormalAskSetting message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns NormalAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.NormalAskSetting;
+
+        /**
+         * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns NormalAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.NormalAskSetting;
+
+        /**
+         * Verifies a NormalAskSetting message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns NormalAskSetting
+         */
+        public static fromObject(object: { [k: string]: any }): main.NormalAskSetting;
+
+        /**
+         * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
+         * @param message NormalAskSetting
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.NormalAskSetting, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this NormalAskSetting to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
     /** NormalAskType enum. */
     enum NormalAskType {
         UNKNOWN = 0,
@@ -2615,113 +2960,6 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a NormalAskSetting. */
-    interface INormalAskSetting {
-
-        /** NormalAskSetting id */
-        id?: (string|null);
-
-        /** NormalAskSetting price_ujpy */
-        price_ujpy?: (string|null);
-
-        /** NormalAskSetting amount_uupx */
-        amount_uupx?: (string|null);
-
-        /** NormalAskSetting ratio_percentage */
-        ratio_percentage?: (string|null);
-
-        /** NormalAskSetting enable */
-        enable?: (boolean|null);
-    }
-
-    /** Represents a NormalAskSetting. */
-    class NormalAskSetting implements INormalAskSetting {
-
-        /**
-         * Constructs a new NormalAskSetting.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.INormalAskSetting);
-
-        /** NormalAskSetting id. */
-        public id: string;
-
-        /** NormalAskSetting price_ujpy. */
-        public price_ujpy: string;
-
-        /** NormalAskSetting amount_uupx. */
-        public amount_uupx: string;
-
-        /** NormalAskSetting ratio_percentage. */
-        public ratio_percentage: string;
-
-        /** NormalAskSetting enable. */
-        public enable: boolean;
-
-        /**
-         * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-         * @param message NormalAskSetting message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.INormalAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-         * @param message NormalAskSetting message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.INormalAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a NormalAskSetting message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns NormalAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.NormalAskSetting;
-
-        /**
-         * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns NormalAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.NormalAskSetting;
-
-        /**
-         * Verifies a NormalAskSetting message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns NormalAskSetting
-         */
-        public static fromObject(object: { [k: string]: any }): main.NormalAskSetting;
-
-        /**
-         * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
-         * @param message NormalAskSetting
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.NormalAskSetting, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this NormalAskSetting to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
     /** Properties of a NormalBidDelete. */
     interface INormalBidDelete {
 
@@ -2806,119 +3044,6 @@ export namespace main {
 
         /**
          * Converts this NormalBidDelete to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
-    /** Properties of a NormalBidHistory. */
-    interface INormalBidHistory {
-
-        /** NormalBidHistory id */
-        id?: (string|null);
-
-        /** NormalBidHistory account_id */
-        account_id?: (string|null);
-
-        /** NormalBidHistory price_ujpy */
-        price_ujpy?: (string|null);
-
-        /** NormalBidHistory amount_uupx */
-        amount_uupx?: (string|null);
-
-        /** NormalBidHistory is_accepted */
-        is_accepted?: (boolean|null);
-
-        /** NormalBidHistory contract_price_ujpy */
-        contract_price_ujpy?: (string|null);
-    }
-
-    /** Represents a NormalBidHistory. */
-    class NormalBidHistory implements INormalBidHistory {
-
-        /**
-         * Constructs a new NormalBidHistory.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.INormalBidHistory);
-
-        /** NormalBidHistory id. */
-        public id: string;
-
-        /** NormalBidHistory account_id. */
-        public account_id: string;
-
-        /** NormalBidHistory price_ujpy. */
-        public price_ujpy: string;
-
-        /** NormalBidHistory amount_uupx. */
-        public amount_uupx: string;
-
-        /** NormalBidHistory is_accepted. */
-        public is_accepted: boolean;
-
-        /** NormalBidHistory contract_price_ujpy. */
-        public contract_price_ujpy: string;
-
-        /**
-         * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-         * @param message NormalBidHistory message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.INormalBidHistory, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-         * @param message NormalBidHistory message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.INormalBidHistory, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a NormalBidHistory message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns NormalBidHistory
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.NormalBidHistory;
-
-        /**
-         * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns NormalBidHistory
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.NormalBidHistory;
-
-        /**
-         * Verifies a NormalBidHistory message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns NormalBidHistory
-         */
-        public static fromObject(object: { [k: string]: any }): main.NormalBidHistory;
-
-        /**
-         * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
-         * @param message NormalBidHistory
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.NormalBidHistory, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this NormalBidHistory to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
@@ -3555,6 +3680,101 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
+    /** Properties of a RenewableAskSetting. */
+    interface IRenewableAskSetting {
+
+        /** RenewableAskSetting id */
+        id?: (string|null);
+
+        /** RenewableAskSetting price_ujpy */
+        price_ujpy?: (string|null);
+
+        /** RenewableAskSetting amount_uspx */
+        amount_uspx?: (string|null);
+    }
+
+    /** Represents a RenewableAskSetting. */
+    class RenewableAskSetting implements IRenewableAskSetting {
+
+        /**
+         * Constructs a new RenewableAskSetting.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.IRenewableAskSetting);
+
+        /** RenewableAskSetting id. */
+        public id: string;
+
+        /** RenewableAskSetting price_ujpy. */
+        public price_ujpy: string;
+
+        /** RenewableAskSetting amount_uspx. */
+        public amount_uspx: string;
+
+        /**
+         * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+         * @param message RenewableAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.IRenewableAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+         * @param message RenewableAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.IRenewableAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a RenewableAskSetting message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns RenewableAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.RenewableAskSetting;
+
+        /**
+         * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns RenewableAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.RenewableAskSetting;
+
+        /**
+         * Verifies a RenewableAskSetting message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns RenewableAskSetting
+         */
+        public static fromObject(object: { [k: string]: any }): main.RenewableAskSetting;
+
+        /**
+         * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
+         * @param message RenewableAskSetting
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.RenewableAskSetting, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this RenewableAskSetting to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
     /** RenewableAskType enum. */
     enum RenewableAskType {
         UNKNOWN = 0,
@@ -3670,101 +3890,6 @@ export namespace main {
 
         /**
          * Converts this RenewableAsk to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
-    /** Properties of a RenewableAskSetting. */
-    interface IRenewableAskSetting {
-
-        /** RenewableAskSetting id */
-        id?: (string|null);
-
-        /** RenewableAskSetting price_ujpy */
-        price_ujpy?: (string|null);
-
-        /** RenewableAskSetting amount_uspx */
-        amount_uspx?: (string|null);
-    }
-
-    /** Represents a RenewableAskSetting. */
-    class RenewableAskSetting implements IRenewableAskSetting {
-
-        /**
-         * Constructs a new RenewableAskSetting.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.IRenewableAskSetting);
-
-        /** RenewableAskSetting id. */
-        public id: string;
-
-        /** RenewableAskSetting price_ujpy. */
-        public price_ujpy: string;
-
-        /** RenewableAskSetting amount_uspx. */
-        public amount_uspx: string;
-
-        /**
-         * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-         * @param message RenewableAskSetting message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.IRenewableAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-         * @param message RenewableAskSetting message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.IRenewableAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a RenewableAskSetting message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns RenewableAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.RenewableAskSetting;
-
-        /**
-         * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns RenewableAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.RenewableAskSetting;
-
-        /**
-         * Verifies a RenewableAskSetting message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns RenewableAskSetting
-         */
-        public static fromObject(object: { [k: string]: any }): main.RenewableAskSetting;
-
-        /**
-         * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
-         * @param message RenewableAskSetting
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.RenewableAskSetting, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this RenewableAskSetting to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };

--- a/common/src/proto.js
+++ b/common/src/proto.js
@@ -16,226 +16,6 @@ export const main = $root.main = (() => {
      */
     const main = {};
 
-    main.AccountantAccount = (function() {
-
-        /**
-         * Properties of an AccountantAccount.
-         * @memberof main
-         * @interface IAccountantAccount
-         * @property {string|null} [id] AccountantAccount id
-         * @property {string|null} [name] AccountantAccount name
-         * @property {string|null} [xrp_address] AccountantAccount xrp_address
-         */
-
-        /**
-         * Constructs a new AccountantAccount.
-         * @memberof main
-         * @classdesc Represents an AccountantAccount.
-         * @implements IAccountantAccount
-         * @constructor
-         * @param {main.IAccountantAccount=} [properties] Properties to set
-         */
-        function AccountantAccount(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * AccountantAccount id.
-         * @member {string} id
-         * @memberof main.AccountantAccount
-         * @instance
-         */
-        AccountantAccount.prototype.id = "";
-
-        /**
-         * AccountantAccount name.
-         * @member {string} name
-         * @memberof main.AccountantAccount
-         * @instance
-         */
-        AccountantAccount.prototype.name = "";
-
-        /**
-         * AccountantAccount xrp_address.
-         * @member {string} xrp_address
-         * @memberof main.AccountantAccount
-         * @instance
-         */
-        AccountantAccount.prototype.xrp_address = "";
-
-        /**
-         * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-         * @function encode
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        AccountantAccount.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.name);
-            if (message.xrp_address != null && Object.hasOwnProperty.call(message, "xrp_address"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.xrp_address);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        AccountantAccount.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes an AccountantAccount message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.AccountantAccount} AccountantAccount
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        AccountantAccount.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.AccountantAccount();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.name = reader.string();
-                    break;
-                case 3:
-                    message.xrp_address = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.AccountantAccount} AccountantAccount
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        AccountantAccount.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies an AccountantAccount message.
-         * @function verify
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        AccountantAccount.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.name != null && message.hasOwnProperty("name"))
-                if (!$util.isString(message.name))
-                    return "name: string expected";
-            if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
-                if (!$util.isString(message.xrp_address))
-                    return "xrp_address: string expected";
-            return null;
-        };
-
-        /**
-         * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.AccountantAccount} AccountantAccount
-         */
-        AccountantAccount.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.AccountantAccount)
-                return object;
-            let message = new $root.main.AccountantAccount();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.name != null)
-                message.name = String(object.name);
-            if (object.xrp_address != null)
-                message.xrp_address = String(object.xrp_address);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {main.AccountantAccount} message AccountantAccount
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        AccountantAccount.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.name = "";
-                object.xrp_address = "";
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.name != null && message.hasOwnProperty("name"))
-                object.name = message.name;
-            if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
-                object.xrp_address = message.xrp_address;
-            return object;
-        };
-
-        /**
-         * Converts this AccountantAccount to JSON.
-         * @function toJSON
-         * @memberof main.AccountantAccount
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        AccountantAccount.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return AccountantAccount;
-    })();
-
     main.AccountPrivate = (function() {
 
         /**
@@ -476,6 +256,226 @@ export const main = $root.main = (() => {
         };
 
         return AccountPrivate;
+    })();
+
+    main.AccountantAccount = (function() {
+
+        /**
+         * Properties of an AccountantAccount.
+         * @memberof main
+         * @interface IAccountantAccount
+         * @property {string|null} [id] AccountantAccount id
+         * @property {string|null} [name] AccountantAccount name
+         * @property {string|null} [xrp_address] AccountantAccount xrp_address
+         */
+
+        /**
+         * Constructs a new AccountantAccount.
+         * @memberof main
+         * @classdesc Represents an AccountantAccount.
+         * @implements IAccountantAccount
+         * @constructor
+         * @param {main.IAccountantAccount=} [properties] Properties to set
+         */
+        function AccountantAccount(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * AccountantAccount id.
+         * @member {string} id
+         * @memberof main.AccountantAccount
+         * @instance
+         */
+        AccountantAccount.prototype.id = "";
+
+        /**
+         * AccountantAccount name.
+         * @member {string} name
+         * @memberof main.AccountantAccount
+         * @instance
+         */
+        AccountantAccount.prototype.name = "";
+
+        /**
+         * AccountantAccount xrp_address.
+         * @member {string} xrp_address
+         * @memberof main.AccountantAccount
+         * @instance
+         */
+        AccountantAccount.prototype.xrp_address = "";
+
+        /**
+         * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+         * @function encode
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AccountantAccount.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.name);
+            if (message.xrp_address != null && Object.hasOwnProperty.call(message, "xrp_address"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.xrp_address);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AccountantAccount.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an AccountantAccount message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.AccountantAccount} AccountantAccount
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AccountantAccount.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.AccountantAccount();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.name = reader.string();
+                    break;
+                case 3:
+                    message.xrp_address = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.AccountantAccount} AccountantAccount
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AccountantAccount.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an AccountantAccount message.
+         * @function verify
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        AccountantAccount.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.name != null && message.hasOwnProperty("name"))
+                if (!$util.isString(message.name))
+                    return "name: string expected";
+            if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
+                if (!$util.isString(message.xrp_address))
+                    return "xrp_address: string expected";
+            return null;
+        };
+
+        /**
+         * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.AccountantAccount} AccountantAccount
+         */
+        AccountantAccount.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.AccountantAccount)
+                return object;
+            let message = new $root.main.AccountantAccount();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.name != null)
+                message.name = String(object.name);
+            if (object.xrp_address != null)
+                message.xrp_address = String(object.xrp_address);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {main.AccountantAccount} message AccountantAccount
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        AccountantAccount.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.name = "";
+                object.xrp_address = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.name != null && message.hasOwnProperty("name"))
+                object.name = message.name;
+            if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
+                object.xrp_address = message.xrp_address;
+            return object;
+        };
+
+        /**
+         * Converts this AccountantAccount to JSON.
+         * @function toJSON
+         * @memberof main.AccountantAccount
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        AccountantAccount.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return AccountantAccount;
     })();
 
     /**
@@ -1565,248 +1565,6 @@ export const main = $root.main = (() => {
         return AvailableBalance;
     })();
 
-    main.Balance = (function() {
-
-        /**
-         * Properties of a Balance.
-         * @memberof main
-         * @interface IBalance
-         * @property {string|null} [id] Balance id
-         * @property {string|null} [student_account_id] Balance student_account_id
-         * @property {string|null} [amount_uupx] Balance amount_uupx
-         * @property {string|null} [amount_uspx] Balance amount_uspx
-         */
-
-        /**
-         * Constructs a new Balance.
-         * @memberof main
-         * @classdesc Represents a Balance.
-         * @implements IBalance
-         * @constructor
-         * @param {main.IBalance=} [properties] Properties to set
-         */
-        function Balance(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * Balance id.
-         * @member {string} id
-         * @memberof main.Balance
-         * @instance
-         */
-        Balance.prototype.id = "";
-
-        /**
-         * Balance student_account_id.
-         * @member {string} student_account_id
-         * @memberof main.Balance
-         * @instance
-         */
-        Balance.prototype.student_account_id = "";
-
-        /**
-         * Balance amount_uupx.
-         * @member {string} amount_uupx
-         * @memberof main.Balance
-         * @instance
-         */
-        Balance.prototype.amount_uupx = "";
-
-        /**
-         * Balance amount_uspx.
-         * @member {string} amount_uspx
-         * @memberof main.Balance
-         * @instance
-         */
-        Balance.prototype.amount_uspx = "";
-
-        /**
-         * Encodes the specified Balance message. Does not implicitly {@link main.Balance.verify|verify} messages.
-         * @function encode
-         * @memberof main.Balance
-         * @static
-         * @param {main.IBalance} message Balance message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        Balance.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.student_account_id);
-            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
-            if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uspx);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified Balance message, length delimited. Does not implicitly {@link main.Balance.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.Balance
-         * @static
-         * @param {main.IBalance} message Balance message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        Balance.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes a Balance message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.Balance
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.Balance} Balance
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        Balance.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.Balance();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.student_account_id = reader.string();
-                    break;
-                case 3:
-                    message.amount_uupx = reader.string();
-                    break;
-                case 4:
-                    message.amount_uspx = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes a Balance message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.Balance
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.Balance} Balance
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        Balance.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies a Balance message.
-         * @function verify
-         * @memberof main.Balance
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        Balance.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
-                if (!$util.isString(message.student_account_id))
-                    return "student_account_id: string expected";
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                if (!$util.isString(message.amount_uupx))
-                    return "amount_uupx: string expected";
-            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                if (!$util.isString(message.amount_uspx))
-                    return "amount_uspx: string expected";
-            return null;
-        };
-
-        /**
-         * Creates a Balance message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.Balance
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.Balance} Balance
-         */
-        Balance.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.Balance)
-                return object;
-            let message = new $root.main.Balance();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.student_account_id != null)
-                message.student_account_id = String(object.student_account_id);
-            if (object.amount_uupx != null)
-                message.amount_uupx = String(object.amount_uupx);
-            if (object.amount_uspx != null)
-                message.amount_uspx = String(object.amount_uspx);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from a Balance message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.Balance
-         * @static
-         * @param {main.Balance} message Balance
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        Balance.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.student_account_id = "";
-                object.amount_uupx = "";
-                object.amount_uspx = "";
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
-                object.student_account_id = message.student_account_id;
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                object.amount_uupx = message.amount_uupx;
-            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                object.amount_uspx = message.amount_uspx;
-            return object;
-        };
-
-        /**
-         * Converts this Balance to JSON.
-         * @function toJSON
-         * @memberof main.Balance
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        Balance.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return Balance;
-    })();
-
     main.BalanceSnapshot = (function() {
 
         /**
@@ -2047,6 +1805,248 @@ export const main = $root.main = (() => {
         };
 
         return BalanceSnapshot;
+    })();
+
+    main.Balance = (function() {
+
+        /**
+         * Properties of a Balance.
+         * @memberof main
+         * @interface IBalance
+         * @property {string|null} [id] Balance id
+         * @property {string|null} [student_account_id] Balance student_account_id
+         * @property {string|null} [amount_uupx] Balance amount_uupx
+         * @property {string|null} [amount_uspx] Balance amount_uspx
+         */
+
+        /**
+         * Constructs a new Balance.
+         * @memberof main
+         * @classdesc Represents a Balance.
+         * @implements IBalance
+         * @constructor
+         * @param {main.IBalance=} [properties] Properties to set
+         */
+        function Balance(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * Balance id.
+         * @member {string} id
+         * @memberof main.Balance
+         * @instance
+         */
+        Balance.prototype.id = "";
+
+        /**
+         * Balance student_account_id.
+         * @member {string} student_account_id
+         * @memberof main.Balance
+         * @instance
+         */
+        Balance.prototype.student_account_id = "";
+
+        /**
+         * Balance amount_uupx.
+         * @member {string} amount_uupx
+         * @memberof main.Balance
+         * @instance
+         */
+        Balance.prototype.amount_uupx = "";
+
+        /**
+         * Balance amount_uspx.
+         * @member {string} amount_uspx
+         * @memberof main.Balance
+         * @instance
+         */
+        Balance.prototype.amount_uspx = "";
+
+        /**
+         * Encodes the specified Balance message. Does not implicitly {@link main.Balance.verify|verify} messages.
+         * @function encode
+         * @memberof main.Balance
+         * @static
+         * @param {main.IBalance} message Balance message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Balance.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.student_account_id);
+            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
+            if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uspx);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified Balance message, length delimited. Does not implicitly {@link main.Balance.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.Balance
+         * @static
+         * @param {main.IBalance} message Balance message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        Balance.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a Balance message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.Balance
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.Balance} Balance
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Balance.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.Balance();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.student_account_id = reader.string();
+                    break;
+                case 3:
+                    message.amount_uupx = reader.string();
+                    break;
+                case 4:
+                    message.amount_uspx = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a Balance message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.Balance
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.Balance} Balance
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        Balance.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a Balance message.
+         * @function verify
+         * @memberof main.Balance
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        Balance.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                if (!$util.isString(message.student_account_id))
+                    return "student_account_id: string expected";
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                if (!$util.isString(message.amount_uupx))
+                    return "amount_uupx: string expected";
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                if (!$util.isString(message.amount_uspx))
+                    return "amount_uspx: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a Balance message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.Balance
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.Balance} Balance
+         */
+        Balance.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.Balance)
+                return object;
+            let message = new $root.main.Balance();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.student_account_id != null)
+                message.student_account_id = String(object.student_account_id);
+            if (object.amount_uupx != null)
+                message.amount_uupx = String(object.amount_uupx);
+            if (object.amount_uspx != null)
+                message.amount_uspx = String(object.amount_uspx);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a Balance message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.Balance
+         * @static
+         * @param {main.Balance} message Balance
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        Balance.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.student_account_id = "";
+                object.amount_uupx = "";
+                object.amount_uspx = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                object.student_account_id = message.student_account_id;
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                object.amount_uupx = message.amount_uupx;
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                object.amount_uspx = message.amount_uspx;
+            return object;
+        };
+
+        /**
+         * Converts this Balance to JSON.
+         * @function toJSON
+         * @memberof main.Balance
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        Balance.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return Balance;
     })();
 
     main.ChatDelete = (function() {
@@ -4990,6 +4990,7 @@ export const main = $root.main = (() => {
          * @property {string|null} [amount_adjust_ujpy] MonthlyPayment amount_adjust_ujpy
          * @property {string|null} [amount_market_ujpy] MonthlyPayment amount_market_ujpy
          * @property {string|null} [amount_reward_ujpy] MonthlyPayment amount_reward_ujpy
+         * @property {string|null} [amount_utoken] MonthlyPayment amount_utoken
          */
 
         /**
@@ -5080,6 +5081,14 @@ export const main = $root.main = (() => {
         MonthlyPayment.prototype.amount_reward_ujpy = "";
 
         /**
+         * MonthlyPayment amount_utoken.
+         * @member {string} amount_utoken
+         * @memberof main.MonthlyPayment
+         * @instance
+         */
+        MonthlyPayment.prototype.amount_utoken = "";
+
+        /**
          * Encodes the specified MonthlyPayment message. Does not implicitly {@link main.MonthlyPayment.verify|verify} messages.
          * @function encode
          * @memberof main.MonthlyPayment
@@ -5109,6 +5118,8 @@ export const main = $root.main = (() => {
                 writer.uint32(/* id 8, wireType 2 =*/66).string(message.amount_market_ujpy);
             if (message.amount_reward_ujpy != null && Object.hasOwnProperty.call(message, "amount_reward_ujpy"))
                 writer.uint32(/* id 9, wireType 2 =*/74).string(message.amount_reward_ujpy);
+            if (message.amount_utoken != null && Object.hasOwnProperty.call(message, "amount_utoken"))
+                writer.uint32(/* id 10, wireType 2 =*/82).string(message.amount_utoken);
             return writer;
         };
 
@@ -5169,6 +5180,9 @@ export const main = $root.main = (() => {
                     break;
                 case 9:
                     message.amount_reward_ujpy = reader.string();
+                    break;
+                case 10:
+                    message.amount_utoken = reader.string();
                     break;
                 default:
                     reader.skipType(tag & 7);
@@ -5232,6 +5246,9 @@ export const main = $root.main = (() => {
             if (message.amount_reward_ujpy != null && message.hasOwnProperty("amount_reward_ujpy"))
                 if (!$util.isString(message.amount_reward_ujpy))
                     return "amount_reward_ujpy: string expected";
+            if (message.amount_utoken != null && message.hasOwnProperty("amount_utoken"))
+                if (!$util.isString(message.amount_utoken))
+                    return "amount_utoken: string expected";
             return null;
         };
 
@@ -5265,6 +5282,8 @@ export const main = $root.main = (() => {
                 message.amount_market_ujpy = String(object.amount_market_ujpy);
             if (object.amount_reward_ujpy != null)
                 message.amount_reward_ujpy = String(object.amount_reward_ujpy);
+            if (object.amount_utoken != null)
+                message.amount_utoken = String(object.amount_utoken);
             return message;
         };
 
@@ -5291,6 +5310,7 @@ export const main = $root.main = (() => {
                 object.amount_adjust_ujpy = "";
                 object.amount_market_ujpy = "";
                 object.amount_reward_ujpy = "";
+                object.amount_utoken = "";
             }
             if (message.id != null && message.hasOwnProperty("id"))
                 object.id = message.id;
@@ -5310,6 +5330,8 @@ export const main = $root.main = (() => {
                 object.amount_market_ujpy = message.amount_market_ujpy;
             if (message.amount_reward_ujpy != null && message.hasOwnProperty("amount_reward_ujpy"))
                 object.amount_reward_ujpy = message.amount_reward_ujpy;
+            if (message.amount_utoken != null && message.hasOwnProperty("amount_utoken"))
+                object.amount_utoken = message.amount_utoken;
             return object;
         };
 
@@ -5325,6 +5347,314 @@ export const main = $root.main = (() => {
         };
 
         return MonthlyPayment;
+    })();
+
+    main.MonthlySettlement = (function() {
+
+        /**
+         * Properties of a MonthlySettlement.
+         * @memberof main
+         * @interface IMonthlySettlement
+         * @property {string|null} [id] MonthlySettlement id
+         * @property {string|null} [year] MonthlySettlement year
+         * @property {string|null} [month] MonthlySettlement month
+         * @property {string|null} [reward_ujpy] MonthlySettlement reward_ujpy
+         * @property {string|null} [system_income_ujpy] MonthlySettlement system_income_ujpy
+         * @property {string|null} [purchase_utoken] MonthlySettlement purchase_utoken
+         * @property {string|null} [sale_utoken] MonthlySettlement sale_utoken
+         */
+
+        /**
+         * Constructs a new MonthlySettlement.
+         * @memberof main
+         * @classdesc Represents a MonthlySettlement.
+         * @implements IMonthlySettlement
+         * @constructor
+         * @param {main.IMonthlySettlement=} [properties] Properties to set
+         */
+        function MonthlySettlement(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * MonthlySettlement id.
+         * @member {string} id
+         * @memberof main.MonthlySettlement
+         * @instance
+         */
+        MonthlySettlement.prototype.id = "";
+
+        /**
+         * MonthlySettlement year.
+         * @member {string} year
+         * @memberof main.MonthlySettlement
+         * @instance
+         */
+        MonthlySettlement.prototype.year = "";
+
+        /**
+         * MonthlySettlement month.
+         * @member {string} month
+         * @memberof main.MonthlySettlement
+         * @instance
+         */
+        MonthlySettlement.prototype.month = "";
+
+        /**
+         * MonthlySettlement reward_ujpy.
+         * @member {string} reward_ujpy
+         * @memberof main.MonthlySettlement
+         * @instance
+         */
+        MonthlySettlement.prototype.reward_ujpy = "";
+
+        /**
+         * MonthlySettlement system_income_ujpy.
+         * @member {string} system_income_ujpy
+         * @memberof main.MonthlySettlement
+         * @instance
+         */
+        MonthlySettlement.prototype.system_income_ujpy = "";
+
+        /**
+         * MonthlySettlement purchase_utoken.
+         * @member {string} purchase_utoken
+         * @memberof main.MonthlySettlement
+         * @instance
+         */
+        MonthlySettlement.prototype.purchase_utoken = "";
+
+        /**
+         * MonthlySettlement sale_utoken.
+         * @member {string} sale_utoken
+         * @memberof main.MonthlySettlement
+         * @instance
+         */
+        MonthlySettlement.prototype.sale_utoken = "";
+
+        /**
+         * Encodes the specified MonthlySettlement message. Does not implicitly {@link main.MonthlySettlement.verify|verify} messages.
+         * @function encode
+         * @memberof main.MonthlySettlement
+         * @static
+         * @param {main.IMonthlySettlement} message MonthlySettlement message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        MonthlySettlement.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.year != null && Object.hasOwnProperty.call(message, "year"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.year);
+            if (message.month != null && Object.hasOwnProperty.call(message, "month"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.month);
+            if (message.reward_ujpy != null && Object.hasOwnProperty.call(message, "reward_ujpy"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.reward_ujpy);
+            if (message.system_income_ujpy != null && Object.hasOwnProperty.call(message, "system_income_ujpy"))
+                writer.uint32(/* id 5, wireType 2 =*/42).string(message.system_income_ujpy);
+            if (message.purchase_utoken != null && Object.hasOwnProperty.call(message, "purchase_utoken"))
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.purchase_utoken);
+            if (message.sale_utoken != null && Object.hasOwnProperty.call(message, "sale_utoken"))
+                writer.uint32(/* id 7, wireType 2 =*/58).string(message.sale_utoken);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified MonthlySettlement message, length delimited. Does not implicitly {@link main.MonthlySettlement.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.MonthlySettlement
+         * @static
+         * @param {main.IMonthlySettlement} message MonthlySettlement message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        MonthlySettlement.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a MonthlySettlement message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.MonthlySettlement
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.MonthlySettlement} MonthlySettlement
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        MonthlySettlement.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.MonthlySettlement();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.year = reader.string();
+                    break;
+                case 3:
+                    message.month = reader.string();
+                    break;
+                case 4:
+                    message.reward_ujpy = reader.string();
+                    break;
+                case 5:
+                    message.system_income_ujpy = reader.string();
+                    break;
+                case 6:
+                    message.purchase_utoken = reader.string();
+                    break;
+                case 7:
+                    message.sale_utoken = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a MonthlySettlement message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.MonthlySettlement
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.MonthlySettlement} MonthlySettlement
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        MonthlySettlement.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a MonthlySettlement message.
+         * @function verify
+         * @memberof main.MonthlySettlement
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        MonthlySettlement.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.year != null && message.hasOwnProperty("year"))
+                if (!$util.isString(message.year))
+                    return "year: string expected";
+            if (message.month != null && message.hasOwnProperty("month"))
+                if (!$util.isString(message.month))
+                    return "month: string expected";
+            if (message.reward_ujpy != null && message.hasOwnProperty("reward_ujpy"))
+                if (!$util.isString(message.reward_ujpy))
+                    return "reward_ujpy: string expected";
+            if (message.system_income_ujpy != null && message.hasOwnProperty("system_income_ujpy"))
+                if (!$util.isString(message.system_income_ujpy))
+                    return "system_income_ujpy: string expected";
+            if (message.purchase_utoken != null && message.hasOwnProperty("purchase_utoken"))
+                if (!$util.isString(message.purchase_utoken))
+                    return "purchase_utoken: string expected";
+            if (message.sale_utoken != null && message.hasOwnProperty("sale_utoken"))
+                if (!$util.isString(message.sale_utoken))
+                    return "sale_utoken: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a MonthlySettlement message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.MonthlySettlement
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.MonthlySettlement} MonthlySettlement
+         */
+        MonthlySettlement.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.MonthlySettlement)
+                return object;
+            let message = new $root.main.MonthlySettlement();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.year != null)
+                message.year = String(object.year);
+            if (object.month != null)
+                message.month = String(object.month);
+            if (object.reward_ujpy != null)
+                message.reward_ujpy = String(object.reward_ujpy);
+            if (object.system_income_ujpy != null)
+                message.system_income_ujpy = String(object.system_income_ujpy);
+            if (object.purchase_utoken != null)
+                message.purchase_utoken = String(object.purchase_utoken);
+            if (object.sale_utoken != null)
+                message.sale_utoken = String(object.sale_utoken);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a MonthlySettlement message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.MonthlySettlement
+         * @static
+         * @param {main.MonthlySettlement} message MonthlySettlement
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        MonthlySettlement.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.year = "";
+                object.month = "";
+                object.reward_ujpy = "";
+                object.system_income_ujpy = "";
+                object.purchase_utoken = "";
+                object.sale_utoken = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.year != null && message.hasOwnProperty("year"))
+                object.year = message.year;
+            if (message.month != null && message.hasOwnProperty("month"))
+                object.month = message.month;
+            if (message.reward_ujpy != null && message.hasOwnProperty("reward_ujpy"))
+                object.reward_ujpy = message.reward_ujpy;
+            if (message.system_income_ujpy != null && message.hasOwnProperty("system_income_ujpy"))
+                object.system_income_ujpy = message.system_income_ujpy;
+            if (message.purchase_utoken != null && message.hasOwnProperty("purchase_utoken"))
+                object.purchase_utoken = message.purchase_utoken;
+            if (message.sale_utoken != null && message.hasOwnProperty("sale_utoken"))
+                object.sale_utoken = message.sale_utoken;
+            return object;
+        };
+
+        /**
+         * Converts this MonthlySettlement to JSON.
+         * @function toJSON
+         * @memberof main.MonthlySettlement
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        MonthlySettlement.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return MonthlySettlement;
     })();
 
     main.MonthlyUsage = (function() {
@@ -5789,6 +6119,292 @@ export const main = $root.main = (() => {
         return NormalAskDelete;
     })();
 
+    main.NormalBidHistory = (function() {
+
+        /**
+         * Properties of a NormalBidHistory.
+         * @memberof main
+         * @interface INormalBidHistory
+         * @property {string|null} [id] NormalBidHistory id
+         * @property {string|null} [account_id] NormalBidHistory account_id
+         * @property {string|null} [price_ujpy] NormalBidHistory price_ujpy
+         * @property {string|null} [amount_uupx] NormalBidHistory amount_uupx
+         * @property {boolean|null} [is_accepted] NormalBidHistory is_accepted
+         * @property {string|null} [contract_price_ujpy] NormalBidHistory contract_price_ujpy
+         */
+
+        /**
+         * Constructs a new NormalBidHistory.
+         * @memberof main
+         * @classdesc Represents a NormalBidHistory.
+         * @implements INormalBidHistory
+         * @constructor
+         * @param {main.INormalBidHistory=} [properties] Properties to set
+         */
+        function NormalBidHistory(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * NormalBidHistory id.
+         * @member {string} id
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.id = "";
+
+        /**
+         * NormalBidHistory account_id.
+         * @member {string} account_id
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.account_id = "";
+
+        /**
+         * NormalBidHistory price_ujpy.
+         * @member {string} price_ujpy
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.price_ujpy = "";
+
+        /**
+         * NormalBidHistory amount_uupx.
+         * @member {string} amount_uupx
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.amount_uupx = "";
+
+        /**
+         * NormalBidHistory is_accepted.
+         * @member {boolean} is_accepted
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.is_accepted = false;
+
+        /**
+         * NormalBidHistory contract_price_ujpy.
+         * @member {string} contract_price_ujpy
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.contract_price_ujpy = "";
+
+        /**
+         * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+         * @function encode
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NormalBidHistory.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.account_id != null && Object.hasOwnProperty.call(message, "account_id"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.account_id);
+            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.price_ujpy);
+            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uupx);
+            if (message.is_accepted != null && Object.hasOwnProperty.call(message, "is_accepted"))
+                writer.uint32(/* id 5, wireType 0 =*/40).bool(message.is_accepted);
+            if (message.contract_price_ujpy != null && Object.hasOwnProperty.call(message, "contract_price_ujpy"))
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.contract_price_ujpy);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NormalBidHistory.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a NormalBidHistory message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.NormalBidHistory} NormalBidHistory
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NormalBidHistory.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalBidHistory();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.account_id = reader.string();
+                    break;
+                case 3:
+                    message.price_ujpy = reader.string();
+                    break;
+                case 4:
+                    message.amount_uupx = reader.string();
+                    break;
+                case 5:
+                    message.is_accepted = reader.bool();
+                    break;
+                case 6:
+                    message.contract_price_ujpy = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.NormalBidHistory} NormalBidHistory
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NormalBidHistory.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a NormalBidHistory message.
+         * @function verify
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        NormalBidHistory.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.account_id != null && message.hasOwnProperty("account_id"))
+                if (!$util.isString(message.account_id))
+                    return "account_id: string expected";
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                if (!$util.isString(message.price_ujpy))
+                    return "price_ujpy: string expected";
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                if (!$util.isString(message.amount_uupx))
+                    return "amount_uupx: string expected";
+            if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
+                if (typeof message.is_accepted !== "boolean")
+                    return "is_accepted: boolean expected";
+            if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
+                if (!$util.isString(message.contract_price_ujpy))
+                    return "contract_price_ujpy: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.NormalBidHistory} NormalBidHistory
+         */
+        NormalBidHistory.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.NormalBidHistory)
+                return object;
+            let message = new $root.main.NormalBidHistory();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.account_id != null)
+                message.account_id = String(object.account_id);
+            if (object.price_ujpy != null)
+                message.price_ujpy = String(object.price_ujpy);
+            if (object.amount_uupx != null)
+                message.amount_uupx = String(object.amount_uupx);
+            if (object.is_accepted != null)
+                message.is_accepted = Boolean(object.is_accepted);
+            if (object.contract_price_ujpy != null)
+                message.contract_price_ujpy = String(object.contract_price_ujpy);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {main.NormalBidHistory} message NormalBidHistory
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        NormalBidHistory.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.account_id = "";
+                object.price_ujpy = "";
+                object.amount_uupx = "";
+                object.is_accepted = false;
+                object.contract_price_ujpy = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.account_id != null && message.hasOwnProperty("account_id"))
+                object.account_id = message.account_id;
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                object.price_ujpy = message.price_ujpy;
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                object.amount_uupx = message.amount_uupx;
+            if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
+                object.is_accepted = message.is_accepted;
+            if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
+                object.contract_price_ujpy = message.contract_price_ujpy;
+            return object;
+        };
+
+        /**
+         * Converts this NormalBidHistory to JSON.
+         * @function toJSON
+         * @memberof main.NormalBidHistory
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        NormalBidHistory.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return NormalBidHistory;
+    })();
+
     /**
      * NormalAskHistoryType enum.
      * @name main.NormalAskHistoryType
@@ -6131,6 +6747,270 @@ export const main = $root.main = (() => {
         return NormalAskHistory;
     })();
 
+    main.NormalAskSetting = (function() {
+
+        /**
+         * Properties of a NormalAskSetting.
+         * @memberof main
+         * @interface INormalAskSetting
+         * @property {string|null} [id] NormalAskSetting id
+         * @property {string|null} [price_ujpy] NormalAskSetting price_ujpy
+         * @property {string|null} [amount_uupx] NormalAskSetting amount_uupx
+         * @property {string|null} [ratio_percentage] NormalAskSetting ratio_percentage
+         * @property {boolean|null} [enable] NormalAskSetting enable
+         */
+
+        /**
+         * Constructs a new NormalAskSetting.
+         * @memberof main
+         * @classdesc Represents a NormalAskSetting.
+         * @implements INormalAskSetting
+         * @constructor
+         * @param {main.INormalAskSetting=} [properties] Properties to set
+         */
+        function NormalAskSetting(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * NormalAskSetting id.
+         * @member {string} id
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.id = "";
+
+        /**
+         * NormalAskSetting price_ujpy.
+         * @member {string} price_ujpy
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.price_ujpy = "";
+
+        /**
+         * NormalAskSetting amount_uupx.
+         * @member {string} amount_uupx
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.amount_uupx = "";
+
+        /**
+         * NormalAskSetting ratio_percentage.
+         * @member {string} ratio_percentage
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.ratio_percentage = "";
+
+        /**
+         * NormalAskSetting enable.
+         * @member {boolean} enable
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.enable = false;
+
+        /**
+         * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+         * @function encode
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NormalAskSetting.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
+            if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.ratio_percentage);
+            if (message.enable != null && Object.hasOwnProperty.call(message, "enable"))
+                writer.uint32(/* id 5, wireType 0 =*/40).bool(message.enable);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NormalAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a NormalAskSetting message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.NormalAskSetting} NormalAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NormalAskSetting.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalAskSetting();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.price_ujpy = reader.string();
+                    break;
+                case 3:
+                    message.amount_uupx = reader.string();
+                    break;
+                case 4:
+                    message.ratio_percentage = reader.string();
+                    break;
+                case 5:
+                    message.enable = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.NormalAskSetting} NormalAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NormalAskSetting.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a NormalAskSetting message.
+         * @function verify
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        NormalAskSetting.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                if (!$util.isString(message.price_ujpy))
+                    return "price_ujpy: string expected";
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                if (!$util.isString(message.amount_uupx))
+                    return "amount_uupx: string expected";
+            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                if (!$util.isString(message.ratio_percentage))
+                    return "ratio_percentage: string expected";
+            if (message.enable != null && message.hasOwnProperty("enable"))
+                if (typeof message.enable !== "boolean")
+                    return "enable: boolean expected";
+            return null;
+        };
+
+        /**
+         * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.NormalAskSetting} NormalAskSetting
+         */
+        NormalAskSetting.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.NormalAskSetting)
+                return object;
+            let message = new $root.main.NormalAskSetting();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.price_ujpy != null)
+                message.price_ujpy = String(object.price_ujpy);
+            if (object.amount_uupx != null)
+                message.amount_uupx = String(object.amount_uupx);
+            if (object.ratio_percentage != null)
+                message.ratio_percentage = String(object.ratio_percentage);
+            if (object.enable != null)
+                message.enable = Boolean(object.enable);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {main.NormalAskSetting} message NormalAskSetting
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        NormalAskSetting.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.price_ujpy = "";
+                object.amount_uupx = "";
+                object.ratio_percentage = "";
+                object.enable = false;
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                object.price_ujpy = message.price_ujpy;
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                object.amount_uupx = message.amount_uupx;
+            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                object.ratio_percentage = message.ratio_percentage;
+            if (message.enable != null && message.hasOwnProperty("enable"))
+                object.enable = message.enable;
+            return object;
+        };
+
+        /**
+         * Converts this NormalAskSetting to JSON.
+         * @function toJSON
+         * @memberof main.NormalAskSetting
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        NormalAskSetting.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return NormalAskSetting;
+    })();
+
     /**
      * NormalAskType enum.
      * @name main.NormalAskType
@@ -6451,270 +7331,6 @@ export const main = $root.main = (() => {
         return NormalAsk;
     })();
 
-    main.NormalAskSetting = (function() {
-
-        /**
-         * Properties of a NormalAskSetting.
-         * @memberof main
-         * @interface INormalAskSetting
-         * @property {string|null} [id] NormalAskSetting id
-         * @property {string|null} [price_ujpy] NormalAskSetting price_ujpy
-         * @property {string|null} [amount_uupx] NormalAskSetting amount_uupx
-         * @property {string|null} [ratio_percentage] NormalAskSetting ratio_percentage
-         * @property {boolean|null} [enable] NormalAskSetting enable
-         */
-
-        /**
-         * Constructs a new NormalAskSetting.
-         * @memberof main
-         * @classdesc Represents a NormalAskSetting.
-         * @implements INormalAskSetting
-         * @constructor
-         * @param {main.INormalAskSetting=} [properties] Properties to set
-         */
-        function NormalAskSetting(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * NormalAskSetting id.
-         * @member {string} id
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.id = "";
-
-        /**
-         * NormalAskSetting price_ujpy.
-         * @member {string} price_ujpy
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.price_ujpy = "";
-
-        /**
-         * NormalAskSetting amount_uupx.
-         * @member {string} amount_uupx
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.amount_uupx = "";
-
-        /**
-         * NormalAskSetting ratio_percentage.
-         * @member {string} ratio_percentage
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.ratio_percentage = "";
-
-        /**
-         * NormalAskSetting enable.
-         * @member {boolean} enable
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.enable = false;
-
-        /**
-         * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-         * @function encode
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        NormalAskSetting.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
-            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
-            if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.ratio_percentage);
-            if (message.enable != null && Object.hasOwnProperty.call(message, "enable"))
-                writer.uint32(/* id 5, wireType 0 =*/40).bool(message.enable);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        NormalAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes a NormalAskSetting message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.NormalAskSetting} NormalAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        NormalAskSetting.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalAskSetting();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.price_ujpy = reader.string();
-                    break;
-                case 3:
-                    message.amount_uupx = reader.string();
-                    break;
-                case 4:
-                    message.ratio_percentage = reader.string();
-                    break;
-                case 5:
-                    message.enable = reader.bool();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.NormalAskSetting} NormalAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        NormalAskSetting.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies a NormalAskSetting message.
-         * @function verify
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        NormalAskSetting.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                if (!$util.isString(message.price_ujpy))
-                    return "price_ujpy: string expected";
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                if (!$util.isString(message.amount_uupx))
-                    return "amount_uupx: string expected";
-            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
-                if (!$util.isString(message.ratio_percentage))
-                    return "ratio_percentage: string expected";
-            if (message.enable != null && message.hasOwnProperty("enable"))
-                if (typeof message.enable !== "boolean")
-                    return "enable: boolean expected";
-            return null;
-        };
-
-        /**
-         * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.NormalAskSetting} NormalAskSetting
-         */
-        NormalAskSetting.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.NormalAskSetting)
-                return object;
-            let message = new $root.main.NormalAskSetting();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.price_ujpy != null)
-                message.price_ujpy = String(object.price_ujpy);
-            if (object.amount_uupx != null)
-                message.amount_uupx = String(object.amount_uupx);
-            if (object.ratio_percentage != null)
-                message.ratio_percentage = String(object.ratio_percentage);
-            if (object.enable != null)
-                message.enable = Boolean(object.enable);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {main.NormalAskSetting} message NormalAskSetting
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        NormalAskSetting.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.price_ujpy = "";
-                object.amount_uupx = "";
-                object.ratio_percentage = "";
-                object.enable = false;
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                object.price_ujpy = message.price_ujpy;
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                object.amount_uupx = message.amount_uupx;
-            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
-                object.ratio_percentage = message.ratio_percentage;
-            if (message.enable != null && message.hasOwnProperty("enable"))
-                object.enable = message.enable;
-            return object;
-        };
-
-        /**
-         * Converts this NormalAskSetting to JSON.
-         * @function toJSON
-         * @memberof main.NormalAskSetting
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        NormalAskSetting.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return NormalAskSetting;
-    })();
-
     main.NormalBidDelete = (function() {
 
         /**
@@ -6911,292 +7527,6 @@ export const main = $root.main = (() => {
         };
 
         return NormalBidDelete;
-    })();
-
-    main.NormalBidHistory = (function() {
-
-        /**
-         * Properties of a NormalBidHistory.
-         * @memberof main
-         * @interface INormalBidHistory
-         * @property {string|null} [id] NormalBidHistory id
-         * @property {string|null} [account_id] NormalBidHistory account_id
-         * @property {string|null} [price_ujpy] NormalBidHistory price_ujpy
-         * @property {string|null} [amount_uupx] NormalBidHistory amount_uupx
-         * @property {boolean|null} [is_accepted] NormalBidHistory is_accepted
-         * @property {string|null} [contract_price_ujpy] NormalBidHistory contract_price_ujpy
-         */
-
-        /**
-         * Constructs a new NormalBidHistory.
-         * @memberof main
-         * @classdesc Represents a NormalBidHistory.
-         * @implements INormalBidHistory
-         * @constructor
-         * @param {main.INormalBidHistory=} [properties] Properties to set
-         */
-        function NormalBidHistory(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * NormalBidHistory id.
-         * @member {string} id
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.id = "";
-
-        /**
-         * NormalBidHistory account_id.
-         * @member {string} account_id
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.account_id = "";
-
-        /**
-         * NormalBidHistory price_ujpy.
-         * @member {string} price_ujpy
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.price_ujpy = "";
-
-        /**
-         * NormalBidHistory amount_uupx.
-         * @member {string} amount_uupx
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.amount_uupx = "";
-
-        /**
-         * NormalBidHistory is_accepted.
-         * @member {boolean} is_accepted
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.is_accepted = false;
-
-        /**
-         * NormalBidHistory contract_price_ujpy.
-         * @member {string} contract_price_ujpy
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.contract_price_ujpy = "";
-
-        /**
-         * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-         * @function encode
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        NormalBidHistory.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.account_id != null && Object.hasOwnProperty.call(message, "account_id"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.account_id);
-            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.price_ujpy);
-            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uupx);
-            if (message.is_accepted != null && Object.hasOwnProperty.call(message, "is_accepted"))
-                writer.uint32(/* id 5, wireType 0 =*/40).bool(message.is_accepted);
-            if (message.contract_price_ujpy != null && Object.hasOwnProperty.call(message, "contract_price_ujpy"))
-                writer.uint32(/* id 6, wireType 2 =*/50).string(message.contract_price_ujpy);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        NormalBidHistory.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes a NormalBidHistory message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.NormalBidHistory} NormalBidHistory
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        NormalBidHistory.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalBidHistory();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.account_id = reader.string();
-                    break;
-                case 3:
-                    message.price_ujpy = reader.string();
-                    break;
-                case 4:
-                    message.amount_uupx = reader.string();
-                    break;
-                case 5:
-                    message.is_accepted = reader.bool();
-                    break;
-                case 6:
-                    message.contract_price_ujpy = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.NormalBidHistory} NormalBidHistory
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        NormalBidHistory.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies a NormalBidHistory message.
-         * @function verify
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        NormalBidHistory.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.account_id != null && message.hasOwnProperty("account_id"))
-                if (!$util.isString(message.account_id))
-                    return "account_id: string expected";
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                if (!$util.isString(message.price_ujpy))
-                    return "price_ujpy: string expected";
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                if (!$util.isString(message.amount_uupx))
-                    return "amount_uupx: string expected";
-            if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
-                if (typeof message.is_accepted !== "boolean")
-                    return "is_accepted: boolean expected";
-            if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
-                if (!$util.isString(message.contract_price_ujpy))
-                    return "contract_price_ujpy: string expected";
-            return null;
-        };
-
-        /**
-         * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.NormalBidHistory} NormalBidHistory
-         */
-        NormalBidHistory.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.NormalBidHistory)
-                return object;
-            let message = new $root.main.NormalBidHistory();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.account_id != null)
-                message.account_id = String(object.account_id);
-            if (object.price_ujpy != null)
-                message.price_ujpy = String(object.price_ujpy);
-            if (object.amount_uupx != null)
-                message.amount_uupx = String(object.amount_uupx);
-            if (object.is_accepted != null)
-                message.is_accepted = Boolean(object.is_accepted);
-            if (object.contract_price_ujpy != null)
-                message.contract_price_ujpy = String(object.contract_price_ujpy);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {main.NormalBidHistory} message NormalBidHistory
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        NormalBidHistory.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.account_id = "";
-                object.price_ujpy = "";
-                object.amount_uupx = "";
-                object.is_accepted = false;
-                object.contract_price_ujpy = "";
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.account_id != null && message.hasOwnProperty("account_id"))
-                object.account_id = message.account_id;
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                object.price_ujpy = message.price_ujpy;
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                object.amount_uupx = message.amount_uupx;
-            if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
-                object.is_accepted = message.is_accepted;
-            if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
-                object.contract_price_ujpy = message.contract_price_ujpy;
-            return object;
-        };
-
-        /**
-         * Converts this NormalBidHistory to JSON.
-         * @function toJSON
-         * @memberof main.NormalBidHistory
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        NormalBidHistory.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return NormalBidHistory;
     })();
 
     main.NormalBid = (function() {
@@ -8751,6 +9081,226 @@ export const main = $root.main = (() => {
         return RenewableAskHistory;
     })();
 
+    main.RenewableAskSetting = (function() {
+
+        /**
+         * Properties of a RenewableAskSetting.
+         * @memberof main
+         * @interface IRenewableAskSetting
+         * @property {string|null} [id] RenewableAskSetting id
+         * @property {string|null} [price_ujpy] RenewableAskSetting price_ujpy
+         * @property {string|null} [amount_uspx] RenewableAskSetting amount_uspx
+         */
+
+        /**
+         * Constructs a new RenewableAskSetting.
+         * @memberof main
+         * @classdesc Represents a RenewableAskSetting.
+         * @implements IRenewableAskSetting
+         * @constructor
+         * @param {main.IRenewableAskSetting=} [properties] Properties to set
+         */
+        function RenewableAskSetting(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * RenewableAskSetting id.
+         * @member {string} id
+         * @memberof main.RenewableAskSetting
+         * @instance
+         */
+        RenewableAskSetting.prototype.id = "";
+
+        /**
+         * RenewableAskSetting price_ujpy.
+         * @member {string} price_ujpy
+         * @memberof main.RenewableAskSetting
+         * @instance
+         */
+        RenewableAskSetting.prototype.price_ujpy = "";
+
+        /**
+         * RenewableAskSetting amount_uspx.
+         * @member {string} amount_uspx
+         * @memberof main.RenewableAskSetting
+         * @instance
+         */
+        RenewableAskSetting.prototype.amount_uspx = "";
+
+        /**
+         * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+         * @function encode
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        RenewableAskSetting.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+            if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        RenewableAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a RenewableAskSetting message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.RenewableAskSetting} RenewableAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        RenewableAskSetting.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.RenewableAskSetting();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.price_ujpy = reader.string();
+                    break;
+                case 3:
+                    message.amount_uspx = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.RenewableAskSetting} RenewableAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        RenewableAskSetting.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a RenewableAskSetting message.
+         * @function verify
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        RenewableAskSetting.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                if (!$util.isString(message.price_ujpy))
+                    return "price_ujpy: string expected";
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                if (!$util.isString(message.amount_uspx))
+                    return "amount_uspx: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.RenewableAskSetting} RenewableAskSetting
+         */
+        RenewableAskSetting.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.RenewableAskSetting)
+                return object;
+            let message = new $root.main.RenewableAskSetting();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.price_ujpy != null)
+                message.price_ujpy = String(object.price_ujpy);
+            if (object.amount_uspx != null)
+                message.amount_uspx = String(object.amount_uspx);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {main.RenewableAskSetting} message RenewableAskSetting
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        RenewableAskSetting.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.price_ujpy = "";
+                object.amount_uspx = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                object.price_ujpy = message.price_ujpy;
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                object.amount_uspx = message.amount_uspx;
+            return object;
+        };
+
+        /**
+         * Converts this RenewableAskSetting to JSON.
+         * @function toJSON
+         * @memberof main.RenewableAskSetting
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        RenewableAskSetting.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return RenewableAskSetting;
+    })();
+
     /**
      * RenewableAskType enum.
      * @name main.RenewableAskType
@@ -9069,226 +9619,6 @@ export const main = $root.main = (() => {
         };
 
         return RenewableAsk;
-    })();
-
-    main.RenewableAskSetting = (function() {
-
-        /**
-         * Properties of a RenewableAskSetting.
-         * @memberof main
-         * @interface IRenewableAskSetting
-         * @property {string|null} [id] RenewableAskSetting id
-         * @property {string|null} [price_ujpy] RenewableAskSetting price_ujpy
-         * @property {string|null} [amount_uspx] RenewableAskSetting amount_uspx
-         */
-
-        /**
-         * Constructs a new RenewableAskSetting.
-         * @memberof main
-         * @classdesc Represents a RenewableAskSetting.
-         * @implements IRenewableAskSetting
-         * @constructor
-         * @param {main.IRenewableAskSetting=} [properties] Properties to set
-         */
-        function RenewableAskSetting(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * RenewableAskSetting id.
-         * @member {string} id
-         * @memberof main.RenewableAskSetting
-         * @instance
-         */
-        RenewableAskSetting.prototype.id = "";
-
-        /**
-         * RenewableAskSetting price_ujpy.
-         * @member {string} price_ujpy
-         * @memberof main.RenewableAskSetting
-         * @instance
-         */
-        RenewableAskSetting.prototype.price_ujpy = "";
-
-        /**
-         * RenewableAskSetting amount_uspx.
-         * @member {string} amount_uspx
-         * @memberof main.RenewableAskSetting
-         * @instance
-         */
-        RenewableAskSetting.prototype.amount_uspx = "";
-
-        /**
-         * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-         * @function encode
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        RenewableAskSetting.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
-            if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        RenewableAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes a RenewableAskSetting message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.RenewableAskSetting} RenewableAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        RenewableAskSetting.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.RenewableAskSetting();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.price_ujpy = reader.string();
-                    break;
-                case 3:
-                    message.amount_uspx = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.RenewableAskSetting} RenewableAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        RenewableAskSetting.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies a RenewableAskSetting message.
-         * @function verify
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        RenewableAskSetting.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                if (!$util.isString(message.price_ujpy))
-                    return "price_ujpy: string expected";
-            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                if (!$util.isString(message.amount_uspx))
-                    return "amount_uspx: string expected";
-            return null;
-        };
-
-        /**
-         * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.RenewableAskSetting} RenewableAskSetting
-         */
-        RenewableAskSetting.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.RenewableAskSetting)
-                return object;
-            let message = new $root.main.RenewableAskSetting();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.price_ujpy != null)
-                message.price_ujpy = String(object.price_ujpy);
-            if (object.amount_uspx != null)
-                message.amount_uspx = String(object.amount_uspx);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {main.RenewableAskSetting} message RenewableAskSetting
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        RenewableAskSetting.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.price_ujpy = "";
-                object.amount_uspx = "";
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                object.price_ujpy = message.price_ujpy;
-            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                object.amount_uspx = message.amount_uspx;
-            return object;
-        };
-
-        /**
-         * Converts this RenewableAskSetting to JSON.
-         * @function toJSON
-         * @memberof main.RenewableAskSetting
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        RenewableAskSetting.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return RenewableAskSetting;
     })();
 
     main.RenewableBidDelete = (function() {

--- a/functions/src/balance-snapshots/calc-monthly-usage.ts
+++ b/functions/src/balance-snapshots/calc-monthly-usage.ts
@@ -3,7 +3,7 @@
 /* eslint-disable camelcase */
 // import { balance_snapshot } from '.';
 import { balance } from '../balances';
-import { discount_price } from '../discount-prices';
+// import { discount_price } from '../discount-prices';
 import { insufficient_balance } from '../insufficient-balances';
 import { monthly_payment } from '../monthly-payments';
 import { monthly_usage } from '../monthly-usages';
@@ -32,13 +32,13 @@ export const balanceSnapshotOnCreate = async (snapshot: any, context: any) => {
   const normalAsks = await normal_ask_history.listLastMonth(data.student_account_id);
   const renewableBids = await renewable_bid_history.listLastMonth(data.student_account_id);
   const renewableAsks = await renewable_ask_history.listLastMonth(data.student_account_id);
-  const discounts = await discount_price.listLatest();
+  // const discounts = await discount_price.listLatest();
   const uspxRanking = await renewable_ranking.getLatest();
   const rewardSetting = await renewable_reward_setting.getLatest();
 
   let usage: number;
   let primaryPayment: number;
-  let adjustPayment: number;
+  // let adjustPayment: number;
 
   // primaryPayment, adjustPaymentの算出
   if (primaryAsks.length) {
@@ -47,19 +47,19 @@ export const balanceSnapshotOnCreate = async (snapshot: any, context: any) => {
       (previous, current) => previous + (parseInt(current.price_ujpy) * parseInt(current.amount_uupx)) / 1000000,
       0,
     );
-    if (tokens >= 0) {
-      adjustPayment = -((parseInt(primaryAsks[0].price_ujpy) - parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
-    } else {
-      adjustPayment = -((parseInt(primaryAsks[0].price_ujpy) + parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
-    }
+    // if (tokens >= 0) {
+    //   adjustPayment = -((parseInt(primaryAsks[0].price_ujpy) - parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
+    // } else {
+    //   adjustPayment = -((parseInt(primaryAsks[0].price_ujpy) + parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
+    // }
   } else {
     usage = -tokens;
     primaryPayment = 0;
-    if (tokens >= 0) {
-      adjustPayment = -((27 * 1000000 - parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
-    } else {
-      adjustPayment = -((27 * 1000000 + parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
-    }
+    // if (tokens >= 0) {
+    //   adjustPayment = -((27 * 1000000 - parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
+    // } else {
+    //   adjustPayment = -((27 * 1000000 + parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
+    // }
   }
 
   // rewardPaymentの算出
@@ -119,11 +119,12 @@ export const balanceSnapshotOnCreate = async (snapshot: any, context: any) => {
       student_account_id: data.student_account_id,
       year: date.getFullYear().toString(),
       month: date.getMonth().toString(),
-      amount_ujpy: (primaryPayment + adjustPayment + marketPayment + rewardPayment).toString(),
+      amount_ujpy: (primaryPayment + marketPayment + rewardPayment).toString(),
       amount_primary_ujpy: primaryPayment.toString(),
-      amount_adjust_ujpy: adjustPayment.toString(),
+      // amount_adjust_ujpy: adjustPayment.toString(),
       amount_market_ujpy: marketPayment.toString(),
       amount_reward_ujpy: rewardPayment.toString(),
+      amount_utoken: tokens.toString(),
     }),
   );
   const monthlyUsage = new MonthlyUsage({

--- a/functions/src/cost-settings/calc-monthly-payment.ts
+++ b/functions/src/cost-settings/calc-monthly-payment.ts
@@ -1,0 +1,58 @@
+/* eslint-disable camelcase */
+import { cost_setting } from '.';
+import { discount_price } from '../discount-prices';
+import { monthly_payment } from '../monthly-payments';
+import { monthly_settlement } from '../monthly-settlements';
+import { primary_ask } from '../primary-asks';
+import { student_account } from '../student-accounts';
+import { CostSetting, DiscountPrice } from '@local/common';
+
+cost_setting.onCreateHandler.push(async (snapshot, context) => {
+  const data = snapshot.data()! as CostSetting;
+  const systemCost = parseInt(data.system_cost_ujpy);
+  const electricityCost = parseInt(data.electricity_cost_ujpy);
+  const monthlySettlement = await monthly_settlement.listLatest();
+  const reward = parseInt(monthlySettlement[0].reward_ujpy);
+  const income = parseInt(monthlySettlement[0].system_income_ujpy);
+  const purchase = parseInt(monthlySettlement[0].purchase_utoken);
+  const sale = parseInt(monthlySettlement[0].sale_utoken);
+  const primaryAsks = await primary_ask.listLastMonth();
+
+  const primaryPrice = primaryAsks.length ? parseInt(primaryAsks[0].price_ujpy) : 27;
+
+  // 0で割るのを避ける
+  let price: number;
+  if (purchase + sale) {
+    price =
+      (systemCost + electricityCost + reward - income + ((purchase - sale) * parseInt(primaryAsks[0].price_ujpy)) / 1000000) /
+      (((purchase + sale) * primaryPrice) / 1000000);
+  } else {
+    price = 0;
+  }
+  console.log('Discount price', price);
+
+  const discountPrice = new DiscountPrice({
+    price_ujpy: Math.floor(price).toString(),
+    amount_purchase_utoken: purchase.toString(),
+    amount_sale_utoken: sale.toString(),
+  });
+  await discount_price.create(discountPrice);
+
+  const students = await student_account.list();
+  for (const student of students) {
+    const monthlyPayments = await monthly_payment.listLatest(student.id);
+    if (monthlyPayments.length) {
+      const monthlyPayment = monthlyPayments[0];
+      const tokens = parseInt(monthlyPayment.amount_utoken);
+      const discount = parseInt(discountPrice.price_ujpy);
+      let adjustPayment: number;
+      if (tokens >= 0) {
+        adjustPayment = -(primaryPrice - discount * tokens) / 1000000;
+      } else {
+        adjustPayment = -(primaryPrice + discount * tokens) / 1000000;
+      }
+      monthlyPayment.amount_adjust_ujpy = adjustPayment.toString();
+      await monthly_payment.update(monthlyPayment);
+    }
+  }
+});

--- a/functions/src/cost-settings/calc-monthly-payment.ts
+++ b/functions/src/cost-settings/calc-monthly-payment.ts
@@ -47,13 +47,16 @@ cost_setting.onCreateHandler.push(async (snapshot, context) => {
       const discount = parseInt(discountPrice.price_ujpy);
       let adjustPayment: number;
       if (tokens >= 0) {
-        adjustPayment = -(primaryPrice - discount * tokens) / 1000000;
+        adjustPayment = -((primaryPrice - discount) * tokens) / 1000000;
       } else {
-        adjustPayment = -(primaryPrice + discount * tokens) / 1000000;
+        adjustPayment = -((primaryPrice + discount) * tokens) / 1000000;
       }
-      monthlyPayment.amount_adjust_ujpy = adjustPayment.toString();
-      monthlyPayment.amount_ujpy = (parseInt(monthlyPayment.amount_ujpy) + adjustPayment).toString();
-      await monthly_payment.update(monthlyPayment);
+      await monthly_payment.update({
+        id: monthlyPayment.id,
+        student_account_id: monthlyPayment.student_account_id,
+        amount_adjust_ujpy: adjustPayment.toString(),
+        amount_ujpy: (parseInt(monthlyPayment.amount_ujpy) + adjustPayment).toString(),
+      });
     }
   }
 });

--- a/functions/src/cost-settings/calc-monthly-payment.ts
+++ b/functions/src/cost-settings/calc-monthly-payment.ts
@@ -24,8 +24,9 @@ cost_setting.onCreateHandler.push(async (snapshot, context) => {
   let price: number;
   if (purchase + sale) {
     price =
-      (systemCost + electricityCost + reward - income + ((purchase - sale) * parseInt(primaryAsks[0].price_ujpy)) / 1000000) /
-      (((purchase + sale) * primaryPrice) / 1000000);
+      ((systemCost + electricityCost + reward - income + ((purchase - sale) * parseInt(primaryAsks[0].price_ujpy)) / 1000000) /
+        (((purchase + sale) * primaryPrice) / 1000000)) *
+      1000000;
   } else {
     price = 0;
   }

--- a/functions/src/cost-settings/calc-monthly-payment.ts
+++ b/functions/src/cost-settings/calc-monthly-payment.ts
@@ -52,6 +52,7 @@ cost_setting.onCreateHandler.push(async (snapshot, context) => {
         adjustPayment = -(primaryPrice + discount * tokens) / 1000000;
       }
       monthlyPayment.amount_adjust_ujpy = adjustPayment.toString();
+      monthlyPayment.amount_ujpy = (parseInt(monthlyPayment.amount_ujpy) + adjustPayment).toString();
       await monthly_payment.update(monthlyPayment);
     }
   }

--- a/functions/src/cost-settings/controller.ts
+++ b/functions/src/cost-settings/controller.ts
@@ -1,30 +1,29 @@
 import { FirestoreCreateHandler, FirestoreDeleteHandler, FirestoreUpdateHandler } from '../triggers';
-
-// import { isTriggeredOnce } from '../triggers/module';
-// import { CostSettingFirestore } from '@local/common';
-// import * as functions from 'firebase-functions';
+import { isTriggeredOnce } from '../triggers/module';
+import { CostSettingFirestore } from '@local/common';
+import * as functions from 'firebase-functions';
 
 export const onCreateHandler: FirestoreCreateHandler[] = [];
 export const onUpdateHandler: FirestoreUpdateHandler[] = [];
 export const onDeleteHandler: FirestoreDeleteHandler[] = [];
 
-// const f = functions.region('asia-northeast1');
-// export const onCreate = f.firestore.document(CostSettingFirestore.virtualPath).onCreate(async (snapshot, context) => {
-//   if (await isTriggeredOnce(context.eventId)) {
-//     return;
-//   }
+const f = functions.region('asia-northeast1').runWith({ timeoutSeconds: 540, memory: '2GB' });
+module.exports.onCreate = f.firestore.document(CostSettingFirestore.virtualPath).onCreate(async (snapshot, context) => {
+  if (await isTriggeredOnce(context.eventId)) {
+    return;
+  }
 
-//   for (const handler of onCreateHandler) {
-//     try {
-//       await handler(snapshot, context);
-//     } catch (e) {
-//       console.error(`Error: in function ${handler.name}`);
-//       console.error(e);
-//     }
-//   }
-// });
+  for (const handler of onCreateHandler) {
+    try {
+      await handler(snapshot, context);
+    } catch (e) {
+      console.error(`Error: in function ${handler.name}`);
+      console.error(e);
+    }
+  }
+});
 
-// export const onUpdate = f.firestore.document(CostSettingFirestore.virtualPath).onUpdate(async (snapshot, context) => {
+// module.exports.onUpdate = f.firestore.document(CostSettingFirestore.virtualPath).onUpdate(async (snapshot, context) => {
 //   if (await isTriggeredOnce(context.eventId)) {
 //     return;
 //   }
@@ -39,7 +38,7 @@ export const onDeleteHandler: FirestoreDeleteHandler[] = [];
 //   }
 // });
 
-// export const onDelete = f.firestore.document(CostSettingFirestore.virtualPath).onDelete(async (snapshot, context) => {
+// module.exports.onDelete = f.firestore.document(CostSettingFirestore.virtualPath).onDelete(async (snapshot, context) => {
 //   if (await isTriggeredOnce(context.eventId)) {
 //     return;
 //   }

--- a/functions/src/daily-payments/create-balance.ts
+++ b/functions/src/daily-payments/create-balance.ts
@@ -27,7 +27,7 @@ export const dailyPaymentOnCreate = async (snapshot: any, context: any) => {
     );
   }
 
-  const accountPrivate = await account_private.list(data.student_account_id);
+  const accountPrivate = await account_private.listLatest(data.student_account_id);
   if (!accountPrivate.length) {
     console.log(data.student_account_id, 'no XRP address');
     return;

--- a/functions/src/daily-payments/create-balance.ts
+++ b/functions/src/daily-payments/create-balance.ts
@@ -96,6 +96,6 @@ export const dailyPaymentOnCreate = async (snapshot: any, context: any) => {
       // eslint-disable-next-line no-throw-literal
       console.log(`${data.student_account_id} SPX Error sending transaction: ${payResultSPX.result.meta.TransactionResult}`);
     }
-    await await client.disconnect();
+    await client.disconnect();
   }
 };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,6 +3,7 @@ import './accounts/create-student-account';
 import './balance-snapshots/calc-monthly-usage';
 import './balances/update-available-balance';
 import './chat-deletes/delete-chat';
+import './cost-settings/calc-monthly-payment';
 import './daily-payments/create-balance';
 import './message-deletes/delete-message';
 import './message-reads/update-message';
@@ -59,6 +60,7 @@ const files = {
   message_reads: './message-reads',
   messages: './messages',
   monthly_payments: './monthly-payments',
+  monthly_settlements: './monthly-settlements',
   monthly_usages: './monthly-usages',
   normal_ask_deletes: './normal-ask-deletes',
   normal_ask_histories: './normal-ask-histories',

--- a/functions/src/monthly-payments/module.ts
+++ b/functions/src/monthly-payments/module.ts
@@ -3,10 +3,10 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
 /* eslint-disable require-jsdoc */
-import * as admin from 'firebase-admin';
 import { MonthlyPayment, MonthlyPaymentFirestore } from '@local/common';
+import * as admin from 'firebase-admin';
 
-export * from './controller'
+export * from './controller';
 
 export function collection(studentAccountID: string) {
   return admin
@@ -33,15 +33,20 @@ export async function get(studentAccountID: string, id: string) {
     .then((snapshot) => snapshot.data() as MonthlyPayment);
 }
 
+export async function listLatest(studentAccountID: string) {
+  return await collection(studentAccountID)
+    .orderBy('created_at', 'desc')
+    .get()
+    .then((snapshot) => snapshot.docs.map((doc) => doc.data() as MonthlyPayment));
+}
+
 export async function list(studentAccountID: string) {
   return await collection(studentAccountID)
     .get()
     .then((snapshot) => snapshot.docs.map((doc) => doc.data() as MonthlyPayment));
 }
 
-export async function create(
-  data: MonthlyPayment
-) {
+export async function create(data: MonthlyPayment) {
   const doc = document(data.student_account_id);
   data.id = doc.id;
 
@@ -52,9 +57,7 @@ export async function create(
   await doc.set(data);
 }
 
-export async function update(
-  data: MonthlyPayment
-) {
+export async function update(data: MonthlyPayment) {
   const now = admin.firestore.Timestamp.now();
   data.updated_at = now;
 

--- a/functions/src/monthly-payments/module.ts
+++ b/functions/src/monthly-payments/module.ts
@@ -57,7 +57,8 @@ export async function create(data: MonthlyPayment) {
   await doc.set(data);
 }
 
-export async function update(data: MonthlyPayment) {
+// eslint-disable-next-line camelcase
+export async function update(data: Partial<MonthlyPayment> & { id: string } & { student_account_id: string }) {
   const now = admin.firestore.Timestamp.now();
   data.updated_at = now;
 

--- a/functions/src/monthly-settlements/controller.ts
+++ b/functions/src/monthly-settlements/controller.ts
@@ -1,0 +1,55 @@
+import { FirestoreCreateHandler, FirestoreDeleteHandler, FirestoreUpdateHandler } from '../triggers';
+
+// import { isTriggeredOnce } from '../triggers/module';
+// import { MonthlySettlementFirestore } from '@local/common';
+// import * as functions from 'firebase-functions';
+
+export const onCreateHandler: FirestoreCreateHandler[] = [];
+export const onUpdateHandler: FirestoreUpdateHandler[] = [];
+export const onDeleteHandler: FirestoreDeleteHandler[] = [];
+
+// const f = functions.region('asia-northeast1').runWith({ timeoutSeconds: 540, memory: '2GB' });
+// module.exports.onCreate = f.firestore.document(MonthlySettlementFirestore.virtualPath).onCreate(async (snapshot, context) => {
+//   if (await isTriggeredOnce(context.eventId)) {
+//     return;
+//   }
+
+//   for (const handler of onCreateHandler) {
+//     try {
+//       await handler(snapshot, context);
+//     } catch (e) {
+//       console.error(`Error: in function ${handler.name}`);
+//       console.error(e);
+//     }
+//   }
+// });
+
+// module.exports.onUpdate = functions.firestore.document(MonthlySettlementFirestore.virtualPath).onUpdate(async (snapshot, context) => {
+//   if (await isTriggeredOnce(context.eventId)) {
+//     return;
+//   }
+
+//   for (const handler of onUpdateHandler) {
+//     try {
+//       await handler(snapshot, context);
+//     } catch (e) {
+//       console.error(`Error: in function ${handler.name}`);
+//       console.error(e);
+//     }
+//   }
+// });
+
+// module.exports.onDelete = functions.firestore.document(MonthlySettlementFirestore.virtualPath).onDelete(async (snapshot, context) => {
+//   if (await isTriggeredOnce(context.eventId)) {
+//     return;
+//   }
+
+//   for (const handler of onDeleteHandler) {
+//     try {
+//       await handler(snapshot, context);
+//     } catch (e) {
+//       console.error(`Error: in function ${handler.name}`);
+//       console.error(e);
+//     }
+//   }
+// });

--- a/functions/src/monthly-settlements/index.ts
+++ b/functions/src/monthly-settlements/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line camelcase
+export * as monthly_settlement from './module';

--- a/functions/src/monthly-settlements/module.ts
+++ b/functions/src/monthly-settlements/module.ts
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+/* eslint-disable require-jsdoc */
+import { MonthlySettlement, MonthlySettlementFirestore } from '@local/common';
+import * as admin from 'firebase-admin';
+
+export * from './controller';
+
+export function collection() {
+  return admin
+    .firestore()
+    .collection(MonthlySettlementFirestore.collectionPath())
+    .withConverter(MonthlySettlementFirestore.converter as any);
+}
+
+export function collectionGroup() {
+  return admin
+    .firestore()
+    .collectionGroup(MonthlySettlementFirestore.collectionID)
+    .withConverter(MonthlySettlementFirestore.converter as any);
+}
+
+export function document(id?: string) {
+  const col = collection();
+  return id ? col.doc(id) : col.doc();
+}
+
+export async function get(id: string) {
+  return await document(id)
+    .get()
+    .then((snapshot) => snapshot.data() as MonthlySettlement | undefined);
+}
+
+export async function listLatest() {
+  return await collection()
+    .orderBy('created_at', 'desc')
+    .get()
+    .then((snapshot) => snapshot.docs.map((doc) => doc.data() as MonthlySettlement));
+}
+
+export async function list() {
+  return await collection()
+    .get()
+    .then((snapshot) => snapshot.docs.map((doc) => doc.data() as MonthlySettlement));
+}
+
+export async function create(data: MonthlySettlement) {
+  const doc = document(data.id);
+  data.id = doc.id;
+
+  const now = admin.firestore.Timestamp.now();
+  data.created_at = now;
+  data.updated_at = now;
+
+  await doc.set(data);
+}
+
+export async function update(data: Partial<MonthlySettlement> & { id: string }) {
+  const now = admin.firestore.Timestamp.now();
+  data.updated_at = now;
+
+  await document(data.id).update(data);
+}
+
+export async function delete_(id: string) {
+  await document(id).delete();
+}

--- a/functions/src/monthly-usages/create-primary-ask.ts
+++ b/functions/src/monthly-usages/create-primary-ask.ts
@@ -58,7 +58,7 @@ export const monthlyUsageOnCreate = async (snapshot: any, context: any) => {
   // forループで直列に処理する
 
   // XRPL tx
-  const accountPrivate = await account_private.list(data.student_account_id);
+  const accountPrivate = await account_private.listLatest(data.student_account_id);
   if (!accountPrivate.length) {
     console.log(data.student_account_id, 'no XRP address');
     return;

--- a/functions/src/normal-settlements/create-balance.ts
+++ b/functions/src/normal-settlements/create-balance.ts
@@ -91,7 +91,7 @@ export const normalSettlementOnCreate = async (snapshot: any, context: any) => {
     await client.disconnect();
   } else {
     const seller = await student_account.get(data.ask_id);
-    const sellerPrivate = await account_private.list(data.ask_id);
+    const sellerPrivate = await account_private.listLatest(data.ask_id);
     if (!seller.xrp_address) {
       console.log(data.ask_id, 'no XRP address');
       return;

--- a/functions/src/renewable-settlements/create-balance.ts
+++ b/functions/src/renewable-settlements/create-balance.ts
@@ -91,7 +91,7 @@ export const renewableSettlementOnCreate = async (snapshot: any, context: any) =
     await client.disconnect();
   } else {
     const seller = await student_account.get(data.ask_id);
-    const sellerPrivate = await account_private.list(data.ask_id);
+    const sellerPrivate = await account_private.listLatest(data.ask_id);
     if (!seller.xrp_address) {
       console.log(data.ask_id, 'no XRP address');
       return;

--- a/functions/src/schedules/monthly-settlement.ts
+++ b/functions/src/schedules/monthly-settlement.ts
@@ -5,10 +5,9 @@ import { admin_account } from '../admin-accounts';
 import { balance_snapshot } from '../balance-snapshots';
 import { balanceSnapshotOnCreate } from '../balance-snapshots/calc-monthly-usage';
 import { balance } from '../balances';
-import { cost_setting } from '../cost-settings';
 import { daily_payment } from '../daily-payments';
-import { discount_price } from '../discount-prices';
 import { insufficient_balance } from '../insufficient-balances';
+import { monthly_settlement } from '../monthly-settlements';
 import { normal_ask_history } from '../normal-ask-histories';
 import { normal_bid_history } from '../normal-bid-histories';
 import { primary_ask } from '../primary-asks';
@@ -16,7 +15,7 @@ import { renewable_ask_history } from '../renewable-ask-histories';
 import { renewable_ranking } from '../renewable-rankings';
 import { renewable_reward_setting } from '../renewable-reward-settings';
 import { student_account } from '../student-accounts';
-import { BalanceSnapshot, DiscountPrice, RenewableRanking } from '@local/common';
+import { BalanceSnapshot, MonthlySettlement, RenewableRanking } from '@local/common';
 import * as functions from 'firebase-functions';
 
 const f = functions.region('asia-northeast1').runWith({ timeoutSeconds: 540, memory: '2GB', secrets: ['PRIV_KEY'] });
@@ -66,35 +65,50 @@ module.exports.monthlySettlement = f.pubsub
         income += (parseInt(ask.price_ujpy) * parseInt(ask.amount_uspx)) / 1000000;
       }
     }
-
-    const costSetting = await cost_setting.getLatest();
-    // システム運用コスト
-    const cost = !costSetting ? 0 : parseInt(costSetting.system_cost_ujpy);
-    // 電気料金
-    const electricity = !costSetting ? 150000 * 1000000 : parseInt(costSetting.electricity_cost_ujpy);
-
+    const date = new Date();
     const rewardSetting = await renewable_reward_setting.getLatest();
     const reward =
       parseInt(rewardSetting.first_price_ujpy) + parseInt(rewardSetting.second_price_ujpy) + parseInt(rewardSetting.third_price_ujpy);
 
-    // 0で割るのを避ける
-    let price: number;
-    if (purchase + sale) {
-      price =
-        (cost + electricity + reward - income + ((purchase - sale) * parseInt(primaryAsks[0].price_ujpy)) / 1000000) /
-        (((purchase + sale) * parseInt(primaryAsks[0].price_ujpy)) / 1000000);
-    } else {
-      price = 0;
-    }
-    console.log('Discount price', price);
-
-    await discount_price.create(
-      new DiscountPrice({
-        price_ujpy: Math.floor(price).toString(),
-        amount_purchase_utoken: purchase.toString(),
-        amount_sale_utoken: sale.toString(),
+    await monthly_settlement.create(
+      new MonthlySettlement({
+        year: date.getFullYear().toString(),
+        month: date.getMonth().toString(),
+        reward_ujpy: reward.toString(),
+        system_income_ujpy: income.toString(),
+        purchase_utoken: purchase.toString(),
+        sale_utoken: sale.toString(),
       }),
     );
+
+    // const costSetting = await cost_setting.getLatest();
+    // // システム運用コスト
+    // const cost = !costSetting ? 0 : parseInt(costSetting.system_cost_ujpy);
+    // // 電気料金
+    // const electricity = !costSetting ? 150000 * 1000000 : parseInt(costSetting.electricity_cost_ujpy);
+
+    // const rewardSetting = await renewable_reward_setting.getLatest();
+    // const reward =
+    //   parseInt(rewardSetting.first_price_ujpy) + parseInt(rewardSetting.second_price_ujpy) + parseInt(rewardSetting.third_price_ujpy);
+
+    // // 0で割るのを避ける
+    // let price: number;
+    // if (purchase + sale) {
+    //   price =
+    //     (cost + electricity + reward - income + ((purchase - sale) * parseInt(primaryAsks[0].price_ujpy)) / 1000000) /
+    //     (((purchase + sale) * parseInt(primaryAsks[0].price_ujpy)) / 1000000);
+    // } else {
+    //   price = 0;
+    // }
+    // console.log('Discount price', price);
+
+    // await discount_price.create(
+    //   new DiscountPrice({
+    //     price_ujpy: Math.floor(price).toString(),
+    //     amount_purchase_utoken: purchase.toString(),
+    //     amount_sale_utoken: sale.toString(),
+    //   }),
+    // );
 
     const uspxPercentages = [];
     for (const student of students) {

--- a/projects/main/src/app/view/accounts/account/account.component.html
+++ b/projects/main/src/app/view/accounts/account/account.component.html
@@ -139,6 +139,9 @@
             <mat-list-item class="flex flex-wrap" routerLink="/accounts/payments/{{ monthlyPayment.id }}">
               <span class="break-all">{{ monthlyPayment.year }}/{{ monthlyPayment.month }}:</span>
               <span class="flex-auto break-all"></span>
+              <mat-chip-list *ngIf="!monthlyPayment.amount_adjust_ujpy">
+                <mat-chip color="warn" selected>Unsettled</mat-chip>
+              </mat-chip-list>
               <span class="break-all">{{ monthlyPayment.amount_ujpy | microString }} JPY</span>
             </mat-list-item>
           </ng-container>

--- a/projects/main/src/app/view/accounts/payments/payment/payment.component.html
+++ b/projects/main/src/app/view/accounts/payments/payment/payment.component.html
@@ -11,31 +11,45 @@
       <mat-list-item class="flex flex-wrap">
         <span class="break-all">Primary Transaction:</span>
         <span class="flex-auto break-all"></span>
-        <span class="break-all">{{ monthlyPayment?.amount_primary_ujpy | microString }}</span>
+        <span class="break-all">{{ monthlyPayment?.amount_primary_ujpy | microString }} JPY</span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
       <mat-list-item class="flex flex-wrap">
         <span class="break-all">Surplus or Shortage Tokens:</span>
         <span class="flex-auto break-all"></span>
-        <span class="break-all">{{ monthlyPayment?.amount_adjust_ujpy | microString }}</span>
+        <span class="break-all">{{ monthlyPayment?.amount_utoken | microString }}</span>
+      </mat-list-item>
+      <mat-divider [inset]="true"></mat-divider>
+      <mat-list-item class="flex flex-wrap">
+        <span class="break-all">Payment of Surplus or Shortage Tokens:</span>
+        <span class="flex-auto break-all"></span>
+        <ng-container *ngIf="!monthlyPayment?.amount_adjust_ujpy; then empty; else exist"></ng-container>
+        <ng-template #empty>
+          <mat-chip-list>
+            <mat-chip color="warn" selected>Unsettled</mat-chip>
+          </mat-chip-list>
+        </ng-template>
+        <ng-template #exist>
+          <span class="break-all">{{ monthlyPayment?.amount_adjust_ujpy | microString }} JPY</span>
+        </ng-template>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
       <mat-list-item class="flex flex-wrap">
         <span class="break-all">Payments to the Market:</span>
         <span class="flex-auto break-all"></span>
-        <span class="break-all">{{ monthlyPayment?.amount_market_ujpy | microString }}</span>
+        <span class="break-all">{{ monthlyPayment?.amount_market_ujpy | microString }} JPY</span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
       <mat-list-item class="flex flex-wrap">
         <span class="break-all">CO2 Ranking Reward:</span>
         <span class="flex-auto break-all"></span>
-        <span class="break-all">{{ monthlyPayment?.amount_reward_ujpy | microString }}</span>
+        <span class="break-all">{{ monthlyPayment?.amount_reward_ujpy | microString }} JPY</span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
       <mat-list-item class="flex flex-wrap">
         <span class="break-all">Total Payment</span>
         <span class="flex-auto break-all"></span>
-        <span class="break-all">{{ monthlyPayment?.amount_ujpy | microString }}</span>
+        <span class="break-all">{{ monthlyPayment?.amount_ujpy | microString }} JPY</span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
       <mat-list-item class="flex flex-wrap">

--- a/projects/main/src/app/view/accounts/payments/payment/payment.module.ts
+++ b/projects/main/src/app/view/accounts/payments/payment/payment.module.ts
@@ -1,13 +1,14 @@
 import { PaymentComponent } from './payment.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { MatChipsModule } from '@angular/material/chips';
 import { RouterModule } from '@angular/router';
 import { MaterialModule } from 'projects/main/src/app/material.module';
 import { PipesModule } from 'projects/main/src/app/pipes/pipes.module';
 
 @NgModule({
   declarations: [PaymentComponent],
-  imports: [CommonModule, RouterModule, MaterialModule, PipesModule],
+  imports: [CommonModule, RouterModule, MaterialModule, PipesModule, MatChipsModule],
   exports: [PaymentComponent],
 })
 export class PaymentModule {}


### PR DESCRIPTION
トークンの割引額を算出し、余剰/不足トークンを精算するプロセスをcostSettingのOnCreateに切り出し、別のタイミングで発火できるようにした

- [x] 精算に必要な情報をDBに保存する（MonthlySettlement）
- [x] 余剰トークン数の記録（MonthlyPayment）
- [x] 既存のDiscountPrice→AdjustPaymentの算出を廃止
- [x] CostSettingのOnCreateを作成
- [x] フロントエンドに未確定の請求金額の表示を追加

edison-testにて動作確認後、本番環境にdeployします