### PR TITLE
MonthlyPayment作成の一部修正とダウンロード機能の追加

### DIFF
--- a/functions/src/primary-asks/module.ts
+++ b/functions/src/primary-asks/module.ts
@@ -37,6 +37,7 @@ export async function listLastMonth() {
   const now = new Date();
   const lastMonth = new Date();
   lastMonth.setMonth(lastMonth.getMonth() - 1);
+  lastMonth.setHours(0, 0, 0, 0);
 
   return await collection()
     .orderBy('created_at', 'desc')
@@ -50,6 +51,7 @@ export async function listLastMonthByID(accountID: string) {
   const now = new Date();
   const lastMonth = new Date();
   lastMonth.setMonth(lastMonth.getMonth() - 1);
+  lastMonth.setHours(0, 0, 0, 0);
 
   return await collection()
     .orderBy('created_at', 'desc')

--- a/projects/main/src/app/page/admin/dashboard/dashboard.component.html
+++ b/projects/main/src/app/page/admin/dashboard/dashboard.component.html
@@ -15,6 +15,7 @@
   (appDownloadOrders)="onDownloadOrders($event)"
   (appDownloadUserUsages)="onDownloadUserUsages($event)"
   (appDownloadMonthlyUsages)="onDownloadMonthlyUsages($event)"
+  (appDownloadMonthlyPayments)="onDownloadMonthlyPayments($event)"
   (appDownloadNormalBids)="onDownloadNormalBids($event)"
   (appDownloadNormalAsks)="onDownloadNormalAsks($event)"
   (appDownloadRenewableBids)="onDownloadRenewableBids($event)"

--- a/projects/main/src/app/page/admin/dashboard/dashboard.component.ts
+++ b/projects/main/src/app/page/admin/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { DateRange, historyOption, OrderData } from '../../../view/admin/dashboard/dashboard.component';
+import { DateRange, HistoryOption, MonthlyOption, OrderData } from '../../../view/admin/dashboard/dashboard.component';
 import { Ranking } from '../../dashboard/dashboard.component';
 import { Component, OnInit } from '@angular/core';
 import { Timestamp } from '@angular/fire/firestore';
@@ -147,19 +147,23 @@ export class DashboardComponent implements OnInit {
     this.csvDownload.downloadMonthlyUsages($event);
   }
 
-  async onDownloadNormalBids($event: historyOption) {
+  async onDownloadMonthlyPayments($event: MonthlyOption) {
+    this.csvDownload.downloadMonthlyPayments($event.year, $event.month);
+  }
+
+  async onDownloadNormalBids($event: HistoryOption) {
     this.csvHistories.downloadNormalBids($event);
   }
 
-  async onDownloadNormalAsks($event: historyOption) {
+  async onDownloadNormalAsks($event: HistoryOption) {
     await this.csvHistories.downloadNormalAsks($event);
   }
 
-  async onDownloadRenewableBids($event: historyOption) {
+  async onDownloadRenewableBids($event: HistoryOption) {
     this.csvHistories.downloadRenewableBids($event);
   }
 
-  async onDownloadRenewableAsks($event: historyOption) {
+  async onDownloadRenewableAsks($event: HistoryOption) {
     await this.csvHistories.downloadRenewableAsks($event);
   }
 

--- a/projects/main/src/app/view/admin/dashboard/dashboard.component.html
+++ b/projects/main/src/app/view/admin/dashboard/dashboard.component.html
@@ -232,11 +232,40 @@
       >
       </canvas>
       <div class="mt-10">
-        <button mat-flat-button class="w-full" color="accent" (click)="onDownloadMonthlyUsages()">Downoad CSV</button>
+        <button mat-flat-button class="w-full" color="accent" (click)="onDownloadMonthlyUsages()">Download CSV</button>
       </div>
     </ng-template>
   </mat-card>
 
+  <mat-card class="mb-20">
+    <mat-card-title>Monthly Payments Download</mat-card-title>
+    <mat-card-content>
+      <p>EDISON stores data on each user's payment.</p>
+      <p>
+        If adjust_payment is NaN, the settlement of the tokens at the end of the month has not been completed and the final amount may be
+        different.
+      </p>
+    </mat-card-content>
+    <form #formRef="ngForm" (submit)="onDownloadMonthlyPayments(yearRef.value, monthRef.value)">
+      <mat-form-field class="w-1/2">
+        <mat-label>Select Year</mat-label>
+        <mat-select #yearRef required>
+          <mat-option *ngFor="let year of years" [value]="year.value">
+            {{ year.viewValue }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field class="w-1/2">
+        <mat-label>Select Month</mat-label>
+        <mat-select #monthRef required>
+          <mat-option *ngFor="let month of months" [value]="month.value">
+            {{ month.viewValue }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <button mat-flat-button class="w-full" color="primary" type="submit" [disabled]="formRef.invalid">Download Users Payment</button>
+    </form>
+  </mat-card>
   <mat-card class="mb-20">
     <mat-card-title>Daily Electricity Usages</mat-card-title>
     <mat-card-content>

--- a/projects/main/src/app/view/admin/dashboard/dashboard.component.ts
+++ b/projects/main/src/app/view/admin/dashboard/dashboard.component.ts
@@ -1,4 +1,5 @@
 import { Ranking } from '../../../page/dashboard/dashboard.component';
+import { Select } from '../../accounts/room/room.component';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import {
@@ -21,10 +22,15 @@ import {
   usageColors,
 } from 'projects/shared/src/lib/services/charts/chart-monthly-usages/chart-monthly-usage.service';
 
-export interface historyOption {
+export interface HistoryOption {
   onlyContracted: boolean;
   start: Date;
   end: Date;
+}
+
+export interface MonthlyOption {
+  year: number;
+  month: number;
 }
 
 export interface DateRange {
@@ -80,13 +86,15 @@ export class DashboardComponent implements OnInit {
   @Output()
   appDownloadMonthlyUsages: EventEmitter<ChartDataSets[]>;
   @Output()
-  appDownloadNormalBids: EventEmitter<historyOption>;
+  appDownloadMonthlyPayments: EventEmitter<MonthlyOption>;
   @Output()
-  appDownloadNormalAsks: EventEmitter<historyOption>;
+  appDownloadNormalBids: EventEmitter<HistoryOption>;
   @Output()
-  appDownloadRenewableBids: EventEmitter<historyOption>;
+  appDownloadNormalAsks: EventEmitter<HistoryOption>;
   @Output()
-  appDownloadRenewableAsks: EventEmitter<historyOption>;
+  appDownloadRenewableBids: EventEmitter<HistoryOption>;
+  @Output()
+  appDownloadRenewableAsks: EventEmitter<HistoryOption>;
   @Output()
   appDownloadUsages: EventEmitter<DateRange>;
   @Output()
@@ -119,11 +127,33 @@ export class DashboardComponent implements OnInit {
 
   checked: boolean = false;
 
+  years: Select[] = [
+    { value: '0', viewValue: 'All' },
+    { value: '2022', viewValue: '2022' },
+    { value: '2023', viewValue: '2023' },
+  ];
+  months: Select[] = [
+    { value: '0', viewValue: 'All' },
+    { value: '1', viewValue: 'Jan' },
+    { value: '2', viewValue: 'Feb' },
+    { value: '3', viewValue: 'Mar' },
+    { value: '4', viewValue: 'Apr' },
+    { value: '5', viewValue: 'May' },
+    { value: '6', viewValue: 'Jun' },
+    { value: '7', viewValue: 'Jul' },
+    { value: '8', viewValue: 'Aug' },
+    { value: '9', viewValue: 'Sep' },
+    { value: '10', viewValue: 'Oct' },
+    { value: '11', viewValue: 'Nov' },
+    { value: '12', viewValue: 'Dec' },
+  ];
+
   constructor() {
     this.appDownloadBalances = new EventEmitter();
     this.appDownloadOrders = new EventEmitter();
     this.appDownloadUserUsages = new EventEmitter();
     this.appDownloadMonthlyUsages = new EventEmitter();
+    this.appDownloadMonthlyPayments = new EventEmitter();
     this.appDownloadNormalBids = new EventEmitter();
     this.appDownloadNormalAsks = new EventEmitter();
     this.appDownloadRenewableBids = new EventEmitter();
@@ -167,6 +197,16 @@ export class DashboardComponent implements OnInit {
       return;
     }
     this.appDownloadMonthlyUsages.emit(this.totalUsageData);
+  }
+
+  onDownloadMonthlyPayments(year: string, month: string) {
+    const yearNum = parseInt(year);
+    const monthNum = parseInt(month);
+    if ((!yearNum && yearNum != 0) || (!monthNum && monthNum != 0)) {
+      alert('条件を正しく設定してください');
+      return;
+    }
+    this.appDownloadMonthlyPayments.emit({ year: yearNum, month: monthNum });
   }
 
   onDownloadNormalBidHistories() {

--- a/projects/shared/src/lib/services/csvs/csv-order-histories/csv-order-histories.service.ts
+++ b/projects/shared/src/lib/services/csvs/csv-order-histories/csv-order-histories.service.ts
@@ -8,7 +8,7 @@ import { CSVCommonService } from '../csv-common.service';
 import { Injectable } from '@angular/core';
 import { Timestamp } from '@angular/fire/firestore';
 import { NormalAskHistory, NormalBidHistory, RenewableAskHistory, RenewableBidHistory } from '@local/common';
-import { historyOption } from 'projects/main/src/app/view/admin/dashboard/dashboard.component';
+import { HistoryOption } from 'projects/main/src/app/view/admin/dashboard/dashboard.component';
 
 @Injectable({
   providedIn: 'root',
@@ -24,7 +24,7 @@ export class CsvOrderHistoriesService {
     private readonly renewableAskHistoryApp: RenewableAskHistoryApplicationService,
   ) {}
 
-  async downloadNormalBids(option: historyOption) {
+  async downloadNormalBids(option: HistoryOption) {
     const bids = await this.normalBidHistoryApp.listAll();
     const sortContractBids = option.onlyContracted ? bids.filter((bid) => bid.is_accepted) : bids;
     const filteredBids = sortContractBids
@@ -52,7 +52,7 @@ export class CsvOrderHistoriesService {
     this.csvCommon.downloadCsv(csv, 'upx_bid_history');
   }
 
-  async downloadNormalAsks(option: historyOption) {
+  async downloadNormalAsks(option: HistoryOption) {
     const asks = await this.normalAskHistoryApp.listAll();
     const sortContractAsks = option.onlyContracted ? asks.filter((ask) => ask.is_accepted) : asks;
     const filteredAsks = sortContractAsks
@@ -80,7 +80,7 @@ export class CsvOrderHistoriesService {
     this.csvCommon.downloadCsv(csv, 'upx_ask_history');
   }
 
-  async downloadRenewableBids(option: historyOption) {
+  async downloadRenewableBids(option: HistoryOption) {
     const bids = await this.renewableBidHistoryApp.listAll();
     const sortContractBids = option.onlyContracted ? bids.filter((bid) => bid.is_accepted) : bids;
     const filteredBids = sortContractBids
@@ -108,7 +108,7 @@ export class CsvOrderHistoriesService {
     this.csvCommon.downloadCsv(csv, 'spx_bid_history');
   }
 
-  async downloadRenewableAsks(option: historyOption) {
+  async downloadRenewableAsks(option: HistoryOption) {
     const asks = await this.renewableAskHistoryApp.listAll();
     const sortContractAsks = option.onlyContracted ? asks.filter((ask) => ask.is_accepted) : asks;
     const filteredAsks = sortContractAsks

--- a/projects/shared/src/lib/services/student-accounts/monthly-payments/monthly-payment.application.service.ts
+++ b/projects/shared/src/lib/services/student-accounts/monthly-payments/monthly-payment.application.service.ts
@@ -9,6 +9,14 @@ import { map } from 'rxjs/operators';
 export class MonthlyPaymentApplicationService {
   constructor(private readonly monthlyPayment: MonthlyPaymentService) {}
 
+  get(uid: string, paymentID: string) {
+    return this.monthlyPayment.get(uid, paymentID);
+  }
+
+  list(uid: string) {
+    return this.monthlyPayment.list(uid);
+  }
+
   get$(uid: string, paymentID: string) {
     return this.monthlyPayment.get$(uid, paymentID);
   }


### PR DESCRIPTION
MonthlyPayment作成の際のPrimaryAskを取得し金額を算出する箇所でソート条件がシビア過ぎてほとんどがうまく処理できていなかったのでFunctionの修正とFirestore内部の修正を実施。

また、MonthlyPaymentのダウンロード機能がなぜかなかったので急遽実装した。