### PR TITLE
MonthlyUsage計算の修正

### DIFF
--- a/functions/src/balance-snapshots/calc-monthly-usage.ts
+++ b/functions/src/balance-snapshots/calc-monthly-usage.ts
@@ -121,7 +121,7 @@ export const balanceSnapshotOnCreate = async (snapshot: any, context: any) => {
       amount_utoken: tokens.toString(),
     }),
   );
-  const dailyPayments = await daily_payment.listLastMonthFix(data.student_account_id);
+  const dailyPayments = await daily_payment.listLastMonth(data.student_account_id);
   const usage = dailyPayments.reduce((prev, current) => prev + parseInt(current.amount_mwh), 0);
   const monthlyUsage = new MonthlyUsage({
     student_account_id: data.student_account_id,

--- a/functions/src/balance-snapshots/calc-monthly-usage.ts
+++ b/functions/src/balance-snapshots/calc-monthly-usage.ts
@@ -3,6 +3,7 @@
 /* eslint-disable camelcase */
 // import { balance_snapshot } from '.';
 import { balance } from '../balances';
+import { daily_payment } from '../daily-payments';
 // import { discount_price } from '../discount-prices';
 import { insufficient_balance } from '../insufficient-balances';
 import { monthly_payment } from '../monthly-payments';
@@ -36,13 +37,11 @@ export const balanceSnapshotOnCreate = async (snapshot: any, context: any) => {
   const uspxRanking = await renewable_ranking.getLatest();
   const rewardSetting = await renewable_reward_setting.getLatest();
 
-  let usage: number;
   let primaryPayment: number;
   // let adjustPayment: number;
 
   // primaryPayment, adjustPaymentの算出
   if (primaryAsks.length) {
-    usage = primaryAsks.reduce((previous, current) => previous + parseInt(current.amount_uupx), 0) - tokens;
     primaryPayment = primaryAsks.reduce(
       (previous, current) => previous + (parseInt(current.price_ujpy) * parseInt(current.amount_uupx)) / 1000000,
       0,
@@ -53,7 +52,6 @@ export const balanceSnapshotOnCreate = async (snapshot: any, context: any) => {
     //   adjustPayment = -((parseInt(primaryAsks[0].price_ujpy) + parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
     // }
   } else {
-    usage = -tokens;
     primaryPayment = 0;
     // if (tokens >= 0) {
     //   adjustPayment = -((27 * 1000000 - parseInt(discounts[0].price_ujpy)) * tokens) / 1000000;
@@ -78,25 +76,21 @@ export const balanceSnapshotOnCreate = async (snapshot: any, context: any) => {
   let marketPayment = 0;
   for (const normalBid of normalBids) {
     if (normalBid.is_accepted == true) {
-      usage -= parseInt(normalBid.amount_uupx);
       marketPayment += (parseInt(normalBid.contract_price_ujpy) * parseInt(normalBid.amount_uupx)) / 1000000;
     }
   }
   for (const normalAsk of normalAsks) {
     if (normalAsk.is_accepted == true) {
-      usage += parseInt(normalAsk.amount_uupx);
       marketPayment -= (parseInt(normalAsk.contract_price_ujpy) * parseInt(normalAsk.amount_uupx)) / 1000000;
     }
   }
   for (const renewableBid of renewableBids) {
     if (renewableBid.is_accepted == true) {
-      usage -= parseInt(renewableBid.amount_uspx);
       marketPayment += (parseInt(renewableBid.contract_price_ujpy) * parseInt(renewableBid.amount_uspx)) / 1000000;
     }
   }
   for (const renewableAsk of renewableAsks) {
     if (renewableAsk.is_accepted == true) {
-      usage += parseInt(renewableAsk.amount_uspx);
       marketPayment -= (parseInt(renewableAsk.contract_price_ujpy) * parseInt(renewableAsk.amount_uspx)) / 1000000;
     }
   }
@@ -127,6 +121,8 @@ export const balanceSnapshotOnCreate = async (snapshot: any, context: any) => {
       amount_utoken: tokens.toString(),
     }),
   );
+  const dailyPayments = await daily_payment.listLastMonthFix(data.student_account_id);
+  const usage = dailyPayments.reduce((prev, current) => prev + parseInt(current.amount_mwh), 0);
   const monthlyUsage = new MonthlyUsage({
     student_account_id: data.student_account_id,
     year: date.getFullYear().toString(),

--- a/functions/src/balance-snapshots/calc-monthly-usage.ts
+++ b/functions/src/balance-snapshots/calc-monthly-usage.ts
@@ -78,25 +78,25 @@ export const balanceSnapshotOnCreate = async (snapshot: any, context: any) => {
   let marketPayment = 0;
   for (const normalBid of normalBids) {
     if (normalBid.is_accepted == true) {
-      usage += parseInt(normalBid.amount_uupx);
+      usage -= parseInt(normalBid.amount_uupx);
       marketPayment += (parseInt(normalBid.contract_price_ujpy) * parseInt(normalBid.amount_uupx)) / 1000000;
     }
   }
   for (const normalAsk of normalAsks) {
     if (normalAsk.is_accepted == true) {
-      usage -= parseInt(normalAsk.amount_uupx);
+      usage += parseInt(normalAsk.amount_uupx);
       marketPayment -= (parseInt(normalAsk.contract_price_ujpy) * parseInt(normalAsk.amount_uupx)) / 1000000;
     }
   }
   for (const renewableBid of renewableBids) {
     if (renewableBid.is_accepted == true) {
-      usage += parseInt(renewableBid.amount_uspx);
+      usage -= parseInt(renewableBid.amount_uspx);
       marketPayment += (parseInt(renewableBid.contract_price_ujpy) * parseInt(renewableBid.amount_uspx)) / 1000000;
     }
   }
   for (const renewableAsk of renewableAsks) {
     if (renewableAsk.is_accepted == true) {
-      usage -= parseInt(renewableAsk.amount_uspx);
+      usage += parseInt(renewableAsk.amount_uspx);
       marketPayment -= (parseInt(renewableAsk.contract_price_ujpy) * parseInt(renewableAsk.amount_uspx)) / 1000000;
     }
   }

--- a/functions/src/daily-payments/module.ts
+++ b/functions/src/daily-payments/module.ts
@@ -52,18 +52,14 @@ export async function listToday(studentAccountID: string) {
 }
 
 export async function listLastMonth(studentAccountID: string) {
-  const first = new Date();
-  first.setMonth(first.getMonth() - 1);
-  first.setDate(1);
-  first.setHours(0, 0, 0, 0);
-  const end = new Date();
-  end.setDate(1);
-  end.setHours(0, 0, 0, 0);
+  const now = new Date();
+  const lastMonth = new Date();
+  lastMonth.setMonth(lastMonth.getMonth() - 1);
 
   return await collection(studentAccountID)
     .orderBy('created_at', 'desc')
-    .where('created_at', '>', first)
-    .where('created_at', '<', end)
+    .where('created_at', '<', now)
+    .where('created_at', '>', lastMonth)
     .get()
     .then((snapshot) => snapshot.docs.map((doc) => doc.data() as DailyPayment));
 }

--- a/functions/src/daily-usages/module.ts
+++ b/functions/src/daily-usages/module.ts
@@ -55,18 +55,14 @@ export async function listYesterday() {
 }
 
 export async function listLastMonth(roomID: string) {
-  const first = new Date();
-  first.setMonth(first.getMonth() - 1);
-  first.setDate(1);
-  first.setHours(0, 0, 0, 0);
-  const end = new Date();
-  end.setDate(1);
-  end.setHours(0, 0, 0, 0);
+  const now = new Date();
+  const lastMonth = new Date();
+  lastMonth.setMonth(lastMonth.getMonth() - 1);
 
   return await collection()
     .orderBy('created_at', 'desc')
-    .where('created_at', '>', first)
-    .where('created_at', '<', end)
+    .where('created_at', '<', now)
+    .where('created_at', '>', lastMonth)
     .where('room_id', '==', roomID)
     .get()
     .then((snapshot) => snapshot.docs.map((doc) => doc.data() as DailyUsage));

--- a/functions/src/insufficient-balances/module.ts
+++ b/functions/src/insufficient-balances/module.ts
@@ -55,16 +55,13 @@ export async function listThisMonth(studentAccountID: string) {
 }
 
 export async function listLastMonth(studentAccountID: string) {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  const now = new Date();
   const lastMonth = new Date();
-  lastMonth.setDate(lastMonth.getDate() + 1);
   lastMonth.setMonth(lastMonth.getMonth() - 1);
-  lastMonth.setHours(0, 0, 0, 0);
 
   return await collection(studentAccountID)
     .orderBy('created_at', 'desc')
-    .where('created_at', '<', today)
+    .where('created_at', '<', now)
     .where('created_at', '>', lastMonth)
     .get()
     .then((snapshot) => snapshot.docs.map((doc) => doc.data() as InsufficientBalance));

--- a/functions/src/monthly-usages/module.ts
+++ b/functions/src/monthly-usages/module.ts
@@ -38,6 +38,12 @@ export async function list(studentAccountID: string) {
     .get()
     .then((snapshot) => snapshot.docs.map((doc) => doc.data() as MonthlyUsage));
 }
+export async function listLatest(studentAccountID: string) {
+  return await collection(studentAccountID)
+    .orderBy('created_at', 'desc')
+    .get()
+    .then((snapshot) => snapshot.docs.map((doc) => doc.data() as MonthlyUsage));
+}
 
 export async function getLastYear(studentAccountID: string, date: Date) {
   const lastYear1dayAgo = date.setFullYear(date.getFullYear() - 1, date.getMonth() + 1, date.getDate() - 1);
@@ -61,7 +67,7 @@ export async function create(data: MonthlyUsage) {
 }
 
 // eslint-disable-next-line camelcase
-export async function update(data: Partial<MonthlyUsage>& { id: string } & { student_account_id: string }) {
+export async function update(data: Partial<MonthlyUsage> & { id: string } & { student_account_id: string }) {
   const now = admin.firestore.Timestamp.now();
   data.updated_at = now;
 


### PR DESCRIPTION
MonthlyUsage計算について一部符号が逆になっていたため、マイナスの値が入ったりしていた問題を修正

問題の箇所はhttps://github.com/KyotoUniv-SIC/electoric-power-exchange/pull/316/commits/cd5b389238ee76753f9948d095505a99ef538ab6
この部分の計算をDailyPaymentのreduceで行う仕様に変更し、簡略化した