### PR TITLE
基準価格の変更と今後の変更のためのフロントエンド実装

### DIFF
--- a/common/proto/primary_ask_settings/primary_ask_setting.proto
+++ b/common/proto/primary_ask_settings/primary_ask_setting.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package main;
+
+import "firebase_rules_options.proto";
+
+option (google.firebase.rules.firebase_rules).full_package_names = true;
+
+message PrimaryAskSetting {
+  string id = 1;
+  string price_ujpy = 2;
+  string ratio_percentage = 3;
+}

--- a/common/src/entities/primary-ask-settings/index.ts
+++ b/common/src/entities/primary-ask-settings/index.ts
@@ -1,0 +1,2 @@
+export * from './primary-ask-setting.firestore';
+export * from './primary-ask-setting';

--- a/common/src/entities/primary-ask-settings/primary-ask-setting.firestore.ts
+++ b/common/src/entities/primary-ask-settings/primary-ask-setting.firestore.ts
@@ -1,0 +1,25 @@
+import { FirestoreDataConverter } from 'firebase/firestore';
+import { PrimaryAskSetting } from './primary-ask-setting';
+
+
+export class PrimaryAskSettingFirestore {
+  static collectionID = 'primary_ask_settings';
+  static documentID = 'primary_ask_setting_id';
+  static virtualPath = `${PrimaryAskSettingFirestore.collectionID}/{${PrimaryAskSettingFirestore.documentID}}`;
+
+  static converter: FirestoreDataConverter<PrimaryAskSetting> = {
+    toFirestore: (data) => ({ ...data }),
+    fromFirestore: (snapshot, options) => {
+      const data = snapshot.data(options)!;
+      return new PrimaryAskSetting(data, data.created_at, data.updated_at);
+    }
+  };
+
+  static collectionPath() {
+    return `${PrimaryAskSettingFirestore.collectionID}`;
+  }
+
+  static documentPath(id: string) {
+    return `${PrimaryAskSettingFirestore.collectionPath()}/${id}`;
+  }
+}

--- a/common/src/entities/primary-ask-settings/primary-ask-setting.ts
+++ b/common/src/entities/primary-ask-settings/primary-ask-setting.ts
@@ -1,0 +1,12 @@
+import { proto } from '../..';
+import { FieldValue, Timestamp } from 'firebase/firestore';
+
+export class PrimaryAskSetting extends proto.main.PrimaryAskSetting {
+  constructor(iPrimaryAskSetting: proto.main.IPrimaryAskSetting, public created_at?: FieldValue | Timestamp, public updated_at?: FieldValue | Timestamp) {
+    super(iPrimaryAskSetting);
+  }
+
+  validate() {
+    return false;
+  }
+}

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -49,3 +49,4 @@ export * from './entities/renewable-rankings';
 export * from './entities/monthly-settlements';
 export * from './entities/xrpl-txs';
 export * from './entities/xrpl-monthly-txs';
+export * from './entities/primary-ask-settings';

--- a/common/src/proto.cjs
+++ b/common/src/proto.cjs
@@ -25,6 +25,226 @@
          */
         var main = {};
     
+        main.AccountantAccount = (function() {
+    
+            /**
+             * Properties of an AccountantAccount.
+             * @memberof main
+             * @interface IAccountantAccount
+             * @property {string|null} [id] AccountantAccount id
+             * @property {string|null} [name] AccountantAccount name
+             * @property {string|null} [xrp_address] AccountantAccount xrp_address
+             */
+    
+            /**
+             * Constructs a new AccountantAccount.
+             * @memberof main
+             * @classdesc Represents an AccountantAccount.
+             * @implements IAccountantAccount
+             * @constructor
+             * @param {main.IAccountantAccount=} [properties] Properties to set
+             */
+            function AccountantAccount(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * AccountantAccount id.
+             * @member {string} id
+             * @memberof main.AccountantAccount
+             * @instance
+             */
+            AccountantAccount.prototype.id = "";
+    
+            /**
+             * AccountantAccount name.
+             * @member {string} name
+             * @memberof main.AccountantAccount
+             * @instance
+             */
+            AccountantAccount.prototype.name = "";
+    
+            /**
+             * AccountantAccount xrp_address.
+             * @member {string} xrp_address
+             * @memberof main.AccountantAccount
+             * @instance
+             */
+            AccountantAccount.prototype.xrp_address = "";
+    
+            /**
+             * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+             * @function encode
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            AccountantAccount.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.name);
+                if (message.xrp_address != null && Object.hasOwnProperty.call(message, "xrp_address"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.xrp_address);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            AccountantAccount.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes an AccountantAccount message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.AccountantAccount} AccountantAccount
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            AccountantAccount.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.AccountantAccount();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.name = reader.string();
+                        break;
+                    case 3:
+                        message.xrp_address = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.AccountantAccount} AccountantAccount
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            AccountantAccount.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies an AccountantAccount message.
+             * @function verify
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            AccountantAccount.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.name != null && message.hasOwnProperty("name"))
+                    if (!$util.isString(message.name))
+                        return "name: string expected";
+                if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
+                    if (!$util.isString(message.xrp_address))
+                        return "xrp_address: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.AccountantAccount} AccountantAccount
+             */
+            AccountantAccount.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.AccountantAccount)
+                    return object;
+                var message = new $root.main.AccountantAccount();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.name != null)
+                    message.name = String(object.name);
+                if (object.xrp_address != null)
+                    message.xrp_address = String(object.xrp_address);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.AccountantAccount
+             * @static
+             * @param {main.AccountantAccount} message AccountantAccount
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            AccountantAccount.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.name = "";
+                    object.xrp_address = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.name != null && message.hasOwnProperty("name"))
+                    object.name = message.name;
+                if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
+                    object.xrp_address = message.xrp_address;
+                return object;
+            };
+    
+            /**
+             * Converts this AccountantAccount to JSON.
+             * @function toJSON
+             * @memberof main.AccountantAccount
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            AccountantAccount.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return AccountantAccount;
+        })();
+    
         main.AccountPrivate = (function() {
     
             /**
@@ -265,226 +485,6 @@
             };
     
             return AccountPrivate;
-        })();
-    
-        main.AccountantAccount = (function() {
-    
-            /**
-             * Properties of an AccountantAccount.
-             * @memberof main
-             * @interface IAccountantAccount
-             * @property {string|null} [id] AccountantAccount id
-             * @property {string|null} [name] AccountantAccount name
-             * @property {string|null} [xrp_address] AccountantAccount xrp_address
-             */
-    
-            /**
-             * Constructs a new AccountantAccount.
-             * @memberof main
-             * @classdesc Represents an AccountantAccount.
-             * @implements IAccountantAccount
-             * @constructor
-             * @param {main.IAccountantAccount=} [properties] Properties to set
-             */
-            function AccountantAccount(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * AccountantAccount id.
-             * @member {string} id
-             * @memberof main.AccountantAccount
-             * @instance
-             */
-            AccountantAccount.prototype.id = "";
-    
-            /**
-             * AccountantAccount name.
-             * @member {string} name
-             * @memberof main.AccountantAccount
-             * @instance
-             */
-            AccountantAccount.prototype.name = "";
-    
-            /**
-             * AccountantAccount xrp_address.
-             * @member {string} xrp_address
-             * @memberof main.AccountantAccount
-             * @instance
-             */
-            AccountantAccount.prototype.xrp_address = "";
-    
-            /**
-             * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-             * @function encode
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            AccountantAccount.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.name != null && Object.hasOwnProperty.call(message, "name"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.name);
-                if (message.xrp_address != null && Object.hasOwnProperty.call(message, "xrp_address"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.xrp_address);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            AccountantAccount.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes an AccountantAccount message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.AccountantAccount} AccountantAccount
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            AccountantAccount.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.AccountantAccount();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.name = reader.string();
-                        break;
-                    case 3:
-                        message.xrp_address = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.AccountantAccount} AccountantAccount
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            AccountantAccount.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies an AccountantAccount message.
-             * @function verify
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            AccountantAccount.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.name != null && message.hasOwnProperty("name"))
-                    if (!$util.isString(message.name))
-                        return "name: string expected";
-                if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
-                    if (!$util.isString(message.xrp_address))
-                        return "xrp_address: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.AccountantAccount} AccountantAccount
-             */
-            AccountantAccount.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.AccountantAccount)
-                    return object;
-                var message = new $root.main.AccountantAccount();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.name != null)
-                    message.name = String(object.name);
-                if (object.xrp_address != null)
-                    message.xrp_address = String(object.xrp_address);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.AccountantAccount
-             * @static
-             * @param {main.AccountantAccount} message AccountantAccount
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            AccountantAccount.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.name = "";
-                    object.xrp_address = "";
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.name != null && message.hasOwnProperty("name"))
-                    object.name = message.name;
-                if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
-                    object.xrp_address = message.xrp_address;
-                return object;
-            };
-    
-            /**
-             * Converts this AccountantAccount to JSON.
-             * @function toJSON
-             * @memberof main.AccountantAccount
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            AccountantAccount.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return AccountantAccount;
         })();
     
         /**
@@ -1574,248 +1574,6 @@
             return AvailableBalance;
         })();
     
-        main.BalanceSnapshot = (function() {
-    
-            /**
-             * Properties of a BalanceSnapshot.
-             * @memberof main
-             * @interface IBalanceSnapshot
-             * @property {string|null} [id] BalanceSnapshot id
-             * @property {string|null} [student_account_id] BalanceSnapshot student_account_id
-             * @property {string|null} [amount_uupx] BalanceSnapshot amount_uupx
-             * @property {string|null} [amount_uspx] BalanceSnapshot amount_uspx
-             */
-    
-            /**
-             * Constructs a new BalanceSnapshot.
-             * @memberof main
-             * @classdesc Represents a BalanceSnapshot.
-             * @implements IBalanceSnapshot
-             * @constructor
-             * @param {main.IBalanceSnapshot=} [properties] Properties to set
-             */
-            function BalanceSnapshot(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * BalanceSnapshot id.
-             * @member {string} id
-             * @memberof main.BalanceSnapshot
-             * @instance
-             */
-            BalanceSnapshot.prototype.id = "";
-    
-            /**
-             * BalanceSnapshot student_account_id.
-             * @member {string} student_account_id
-             * @memberof main.BalanceSnapshot
-             * @instance
-             */
-            BalanceSnapshot.prototype.student_account_id = "";
-    
-            /**
-             * BalanceSnapshot amount_uupx.
-             * @member {string} amount_uupx
-             * @memberof main.BalanceSnapshot
-             * @instance
-             */
-            BalanceSnapshot.prototype.amount_uupx = "";
-    
-            /**
-             * BalanceSnapshot amount_uspx.
-             * @member {string} amount_uspx
-             * @memberof main.BalanceSnapshot
-             * @instance
-             */
-            BalanceSnapshot.prototype.amount_uspx = "";
-    
-            /**
-             * Encodes the specified BalanceSnapshot message. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
-             * @function encode
-             * @memberof main.BalanceSnapshot
-             * @static
-             * @param {main.IBalanceSnapshot} message BalanceSnapshot message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            BalanceSnapshot.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.student_account_id);
-                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
-                if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uspx);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified BalanceSnapshot message, length delimited. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.BalanceSnapshot
-             * @static
-             * @param {main.IBalanceSnapshot} message BalanceSnapshot message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            BalanceSnapshot.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a BalanceSnapshot message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.BalanceSnapshot
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.BalanceSnapshot} BalanceSnapshot
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            BalanceSnapshot.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.BalanceSnapshot();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.student_account_id = reader.string();
-                        break;
-                    case 3:
-                        message.amount_uupx = reader.string();
-                        break;
-                    case 4:
-                        message.amount_uspx = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a BalanceSnapshot message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.BalanceSnapshot
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.BalanceSnapshot} BalanceSnapshot
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            BalanceSnapshot.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a BalanceSnapshot message.
-             * @function verify
-             * @memberof main.BalanceSnapshot
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            BalanceSnapshot.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
-                    if (!$util.isString(message.student_account_id))
-                        return "student_account_id: string expected";
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    if (!$util.isString(message.amount_uupx))
-                        return "amount_uupx: string expected";
-                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                    if (!$util.isString(message.amount_uspx))
-                        return "amount_uspx: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates a BalanceSnapshot message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.BalanceSnapshot
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.BalanceSnapshot} BalanceSnapshot
-             */
-            BalanceSnapshot.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.BalanceSnapshot)
-                    return object;
-                var message = new $root.main.BalanceSnapshot();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.student_account_id != null)
-                    message.student_account_id = String(object.student_account_id);
-                if (object.amount_uupx != null)
-                    message.amount_uupx = String(object.amount_uupx);
-                if (object.amount_uspx != null)
-                    message.amount_uspx = String(object.amount_uspx);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a BalanceSnapshot message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.BalanceSnapshot
-             * @static
-             * @param {main.BalanceSnapshot} message BalanceSnapshot
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            BalanceSnapshot.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.student_account_id = "";
-                    object.amount_uupx = "";
-                    object.amount_uspx = "";
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
-                    object.student_account_id = message.student_account_id;
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    object.amount_uupx = message.amount_uupx;
-                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                    object.amount_uspx = message.amount_uspx;
-                return object;
-            };
-    
-            /**
-             * Converts this BalanceSnapshot to JSON.
-             * @function toJSON
-             * @memberof main.BalanceSnapshot
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            BalanceSnapshot.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return BalanceSnapshot;
-        })();
-    
         main.Balance = (function() {
     
             /**
@@ -2056,6 +1814,248 @@
             };
     
             return Balance;
+        })();
+    
+        main.BalanceSnapshot = (function() {
+    
+            /**
+             * Properties of a BalanceSnapshot.
+             * @memberof main
+             * @interface IBalanceSnapshot
+             * @property {string|null} [id] BalanceSnapshot id
+             * @property {string|null} [student_account_id] BalanceSnapshot student_account_id
+             * @property {string|null} [amount_uupx] BalanceSnapshot amount_uupx
+             * @property {string|null} [amount_uspx] BalanceSnapshot amount_uspx
+             */
+    
+            /**
+             * Constructs a new BalanceSnapshot.
+             * @memberof main
+             * @classdesc Represents a BalanceSnapshot.
+             * @implements IBalanceSnapshot
+             * @constructor
+             * @param {main.IBalanceSnapshot=} [properties] Properties to set
+             */
+            function BalanceSnapshot(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * BalanceSnapshot id.
+             * @member {string} id
+             * @memberof main.BalanceSnapshot
+             * @instance
+             */
+            BalanceSnapshot.prototype.id = "";
+    
+            /**
+             * BalanceSnapshot student_account_id.
+             * @member {string} student_account_id
+             * @memberof main.BalanceSnapshot
+             * @instance
+             */
+            BalanceSnapshot.prototype.student_account_id = "";
+    
+            /**
+             * BalanceSnapshot amount_uupx.
+             * @member {string} amount_uupx
+             * @memberof main.BalanceSnapshot
+             * @instance
+             */
+            BalanceSnapshot.prototype.amount_uupx = "";
+    
+            /**
+             * BalanceSnapshot amount_uspx.
+             * @member {string} amount_uspx
+             * @memberof main.BalanceSnapshot
+             * @instance
+             */
+            BalanceSnapshot.prototype.amount_uspx = "";
+    
+            /**
+             * Encodes the specified BalanceSnapshot message. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
+             * @function encode
+             * @memberof main.BalanceSnapshot
+             * @static
+             * @param {main.IBalanceSnapshot} message BalanceSnapshot message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            BalanceSnapshot.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.student_account_id);
+                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
+                if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uspx);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified BalanceSnapshot message, length delimited. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.BalanceSnapshot
+             * @static
+             * @param {main.IBalanceSnapshot} message BalanceSnapshot message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            BalanceSnapshot.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a BalanceSnapshot message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.BalanceSnapshot
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.BalanceSnapshot} BalanceSnapshot
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            BalanceSnapshot.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.BalanceSnapshot();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.student_account_id = reader.string();
+                        break;
+                    case 3:
+                        message.amount_uupx = reader.string();
+                        break;
+                    case 4:
+                        message.amount_uspx = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a BalanceSnapshot message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.BalanceSnapshot
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.BalanceSnapshot} BalanceSnapshot
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            BalanceSnapshot.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a BalanceSnapshot message.
+             * @function verify
+             * @memberof main.BalanceSnapshot
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            BalanceSnapshot.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                    if (!$util.isString(message.student_account_id))
+                        return "student_account_id: string expected";
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    if (!$util.isString(message.amount_uupx))
+                        return "amount_uupx: string expected";
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    if (!$util.isString(message.amount_uspx))
+                        return "amount_uspx: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a BalanceSnapshot message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.BalanceSnapshot
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.BalanceSnapshot} BalanceSnapshot
+             */
+            BalanceSnapshot.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.BalanceSnapshot)
+                    return object;
+                var message = new $root.main.BalanceSnapshot();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.student_account_id != null)
+                    message.student_account_id = String(object.student_account_id);
+                if (object.amount_uupx != null)
+                    message.amount_uupx = String(object.amount_uupx);
+                if (object.amount_uspx != null)
+                    message.amount_uspx = String(object.amount_uspx);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a BalanceSnapshot message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.BalanceSnapshot
+             * @static
+             * @param {main.BalanceSnapshot} message BalanceSnapshot
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            BalanceSnapshot.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.student_account_id = "";
+                    object.amount_uupx = "";
+                    object.amount_uspx = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                    object.student_account_id = message.student_account_id;
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    object.amount_uupx = message.amount_uupx;
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    object.amount_uspx = message.amount_uspx;
+                return object;
+            };
+    
+            /**
+             * Converts this BalanceSnapshot to JSON.
+             * @function toJSON
+             * @memberof main.BalanceSnapshot
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            BalanceSnapshot.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return BalanceSnapshot;
         })();
     
         main.ChatDelete = (function() {
@@ -6128,292 +6128,6 @@
             return NormalAskDelete;
         })();
     
-        main.NormalBidHistory = (function() {
-    
-            /**
-             * Properties of a NormalBidHistory.
-             * @memberof main
-             * @interface INormalBidHistory
-             * @property {string|null} [id] NormalBidHistory id
-             * @property {string|null} [account_id] NormalBidHistory account_id
-             * @property {string|null} [price_ujpy] NormalBidHistory price_ujpy
-             * @property {string|null} [amount_uupx] NormalBidHistory amount_uupx
-             * @property {boolean|null} [is_accepted] NormalBidHistory is_accepted
-             * @property {string|null} [contract_price_ujpy] NormalBidHistory contract_price_ujpy
-             */
-    
-            /**
-             * Constructs a new NormalBidHistory.
-             * @memberof main
-             * @classdesc Represents a NormalBidHistory.
-             * @implements INormalBidHistory
-             * @constructor
-             * @param {main.INormalBidHistory=} [properties] Properties to set
-             */
-            function NormalBidHistory(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * NormalBidHistory id.
-             * @member {string} id
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.id = "";
-    
-            /**
-             * NormalBidHistory account_id.
-             * @member {string} account_id
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.account_id = "";
-    
-            /**
-             * NormalBidHistory price_ujpy.
-             * @member {string} price_ujpy
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.price_ujpy = "";
-    
-            /**
-             * NormalBidHistory amount_uupx.
-             * @member {string} amount_uupx
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.amount_uupx = "";
-    
-            /**
-             * NormalBidHistory is_accepted.
-             * @member {boolean} is_accepted
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.is_accepted = false;
-    
-            /**
-             * NormalBidHistory contract_price_ujpy.
-             * @member {string} contract_price_ujpy
-             * @memberof main.NormalBidHistory
-             * @instance
-             */
-            NormalBidHistory.prototype.contract_price_ujpy = "";
-    
-            /**
-             * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-             * @function encode
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            NormalBidHistory.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.account_id != null && Object.hasOwnProperty.call(message, "account_id"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.account_id);
-                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.price_ujpy);
-                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uupx);
-                if (message.is_accepted != null && Object.hasOwnProperty.call(message, "is_accepted"))
-                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.is_accepted);
-                if (message.contract_price_ujpy != null && Object.hasOwnProperty.call(message, "contract_price_ujpy"))
-                    writer.uint32(/* id 6, wireType 2 =*/50).string(message.contract_price_ujpy);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            NormalBidHistory.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a NormalBidHistory message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.NormalBidHistory} NormalBidHistory
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            NormalBidHistory.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalBidHistory();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.account_id = reader.string();
-                        break;
-                    case 3:
-                        message.price_ujpy = reader.string();
-                        break;
-                    case 4:
-                        message.amount_uupx = reader.string();
-                        break;
-                    case 5:
-                        message.is_accepted = reader.bool();
-                        break;
-                    case 6:
-                        message.contract_price_ujpy = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.NormalBidHistory} NormalBidHistory
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            NormalBidHistory.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a NormalBidHistory message.
-             * @function verify
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            NormalBidHistory.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.account_id != null && message.hasOwnProperty("account_id"))
-                    if (!$util.isString(message.account_id))
-                        return "account_id: string expected";
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    if (!$util.isString(message.price_ujpy))
-                        return "price_ujpy: string expected";
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    if (!$util.isString(message.amount_uupx))
-                        return "amount_uupx: string expected";
-                if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
-                    if (typeof message.is_accepted !== "boolean")
-                        return "is_accepted: boolean expected";
-                if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
-                    if (!$util.isString(message.contract_price_ujpy))
-                        return "contract_price_ujpy: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.NormalBidHistory} NormalBidHistory
-             */
-            NormalBidHistory.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.NormalBidHistory)
-                    return object;
-                var message = new $root.main.NormalBidHistory();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.account_id != null)
-                    message.account_id = String(object.account_id);
-                if (object.price_ujpy != null)
-                    message.price_ujpy = String(object.price_ujpy);
-                if (object.amount_uupx != null)
-                    message.amount_uupx = String(object.amount_uupx);
-                if (object.is_accepted != null)
-                    message.is_accepted = Boolean(object.is_accepted);
-                if (object.contract_price_ujpy != null)
-                    message.contract_price_ujpy = String(object.contract_price_ujpy);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.NormalBidHistory
-             * @static
-             * @param {main.NormalBidHistory} message NormalBidHistory
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            NormalBidHistory.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.account_id = "";
-                    object.price_ujpy = "";
-                    object.amount_uupx = "";
-                    object.is_accepted = false;
-                    object.contract_price_ujpy = "";
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.account_id != null && message.hasOwnProperty("account_id"))
-                    object.account_id = message.account_id;
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    object.price_ujpy = message.price_ujpy;
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    object.amount_uupx = message.amount_uupx;
-                if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
-                    object.is_accepted = message.is_accepted;
-                if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
-                    object.contract_price_ujpy = message.contract_price_ujpy;
-                return object;
-            };
-    
-            /**
-             * Converts this NormalBidHistory to JSON.
-             * @function toJSON
-             * @memberof main.NormalBidHistory
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            NormalBidHistory.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return NormalBidHistory;
-        })();
-    
         /**
          * NormalAskHistoryType enum.
          * @name main.NormalAskHistoryType
@@ -6756,270 +6470,6 @@
             return NormalAskHistory;
         })();
     
-        main.NormalAskSetting = (function() {
-    
-            /**
-             * Properties of a NormalAskSetting.
-             * @memberof main
-             * @interface INormalAskSetting
-             * @property {string|null} [id] NormalAskSetting id
-             * @property {string|null} [price_ujpy] NormalAskSetting price_ujpy
-             * @property {string|null} [amount_uupx] NormalAskSetting amount_uupx
-             * @property {string|null} [ratio_percentage] NormalAskSetting ratio_percentage
-             * @property {boolean|null} [enable] NormalAskSetting enable
-             */
-    
-            /**
-             * Constructs a new NormalAskSetting.
-             * @memberof main
-             * @classdesc Represents a NormalAskSetting.
-             * @implements INormalAskSetting
-             * @constructor
-             * @param {main.INormalAskSetting=} [properties] Properties to set
-             */
-            function NormalAskSetting(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * NormalAskSetting id.
-             * @member {string} id
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.id = "";
-    
-            /**
-             * NormalAskSetting price_ujpy.
-             * @member {string} price_ujpy
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.price_ujpy = "";
-    
-            /**
-             * NormalAskSetting amount_uupx.
-             * @member {string} amount_uupx
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.amount_uupx = "";
-    
-            /**
-             * NormalAskSetting ratio_percentage.
-             * @member {string} ratio_percentage
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.ratio_percentage = "";
-    
-            /**
-             * NormalAskSetting enable.
-             * @member {boolean} enable
-             * @memberof main.NormalAskSetting
-             * @instance
-             */
-            NormalAskSetting.prototype.enable = false;
-    
-            /**
-             * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-             * @function encode
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            NormalAskSetting.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
-                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
-                if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
-                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.ratio_percentage);
-                if (message.enable != null && Object.hasOwnProperty.call(message, "enable"))
-                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.enable);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            NormalAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a NormalAskSetting message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.NormalAskSetting} NormalAskSetting
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            NormalAskSetting.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalAskSetting();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.price_ujpy = reader.string();
-                        break;
-                    case 3:
-                        message.amount_uupx = reader.string();
-                        break;
-                    case 4:
-                        message.ratio_percentage = reader.string();
-                        break;
-                    case 5:
-                        message.enable = reader.bool();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.NormalAskSetting} NormalAskSetting
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            NormalAskSetting.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a NormalAskSetting message.
-             * @function verify
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            NormalAskSetting.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    if (!$util.isString(message.price_ujpy))
-                        return "price_ujpy: string expected";
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    if (!$util.isString(message.amount_uupx))
-                        return "amount_uupx: string expected";
-                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
-                    if (!$util.isString(message.ratio_percentage))
-                        return "ratio_percentage: string expected";
-                if (message.enable != null && message.hasOwnProperty("enable"))
-                    if (typeof message.enable !== "boolean")
-                        return "enable: boolean expected";
-                return null;
-            };
-    
-            /**
-             * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.NormalAskSetting} NormalAskSetting
-             */
-            NormalAskSetting.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.NormalAskSetting)
-                    return object;
-                var message = new $root.main.NormalAskSetting();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.price_ujpy != null)
-                    message.price_ujpy = String(object.price_ujpy);
-                if (object.amount_uupx != null)
-                    message.amount_uupx = String(object.amount_uupx);
-                if (object.ratio_percentage != null)
-                    message.ratio_percentage = String(object.ratio_percentage);
-                if (object.enable != null)
-                    message.enable = Boolean(object.enable);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.NormalAskSetting
-             * @static
-             * @param {main.NormalAskSetting} message NormalAskSetting
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            NormalAskSetting.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.price_ujpy = "";
-                    object.amount_uupx = "";
-                    object.ratio_percentage = "";
-                    object.enable = false;
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    object.price_ujpy = message.price_ujpy;
-                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                    object.amount_uupx = message.amount_uupx;
-                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
-                    object.ratio_percentage = message.ratio_percentage;
-                if (message.enable != null && message.hasOwnProperty("enable"))
-                    object.enable = message.enable;
-                return object;
-            };
-    
-            /**
-             * Converts this NormalAskSetting to JSON.
-             * @function toJSON
-             * @memberof main.NormalAskSetting
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            NormalAskSetting.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return NormalAskSetting;
-        })();
-    
         /**
          * NormalAskType enum.
          * @name main.NormalAskType
@@ -7340,6 +6790,270 @@
             return NormalAsk;
         })();
     
+        main.NormalAskSetting = (function() {
+    
+            /**
+             * Properties of a NormalAskSetting.
+             * @memberof main
+             * @interface INormalAskSetting
+             * @property {string|null} [id] NormalAskSetting id
+             * @property {string|null} [price_ujpy] NormalAskSetting price_ujpy
+             * @property {string|null} [amount_uupx] NormalAskSetting amount_uupx
+             * @property {string|null} [ratio_percentage] NormalAskSetting ratio_percentage
+             * @property {boolean|null} [enable] NormalAskSetting enable
+             */
+    
+            /**
+             * Constructs a new NormalAskSetting.
+             * @memberof main
+             * @classdesc Represents a NormalAskSetting.
+             * @implements INormalAskSetting
+             * @constructor
+             * @param {main.INormalAskSetting=} [properties] Properties to set
+             */
+            function NormalAskSetting(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * NormalAskSetting id.
+             * @member {string} id
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.id = "";
+    
+            /**
+             * NormalAskSetting price_ujpy.
+             * @member {string} price_ujpy
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.price_ujpy = "";
+    
+            /**
+             * NormalAskSetting amount_uupx.
+             * @member {string} amount_uupx
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.amount_uupx = "";
+    
+            /**
+             * NormalAskSetting ratio_percentage.
+             * @member {string} ratio_percentage
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.ratio_percentage = "";
+    
+            /**
+             * NormalAskSetting enable.
+             * @member {boolean} enable
+             * @memberof main.NormalAskSetting
+             * @instance
+             */
+            NormalAskSetting.prototype.enable = false;
+    
+            /**
+             * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+             * @function encode
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            NormalAskSetting.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
+                if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.ratio_percentage);
+                if (message.enable != null && Object.hasOwnProperty.call(message, "enable"))
+                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.enable);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            NormalAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a NormalAskSetting message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.NormalAskSetting} NormalAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            NormalAskSetting.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalAskSetting();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.price_ujpy = reader.string();
+                        break;
+                    case 3:
+                        message.amount_uupx = reader.string();
+                        break;
+                    case 4:
+                        message.ratio_percentage = reader.string();
+                        break;
+                    case 5:
+                        message.enable = reader.bool();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.NormalAskSetting} NormalAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            NormalAskSetting.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a NormalAskSetting message.
+             * @function verify
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            NormalAskSetting.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    if (!$util.isString(message.price_ujpy))
+                        return "price_ujpy: string expected";
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    if (!$util.isString(message.amount_uupx))
+                        return "amount_uupx: string expected";
+                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                    if (!$util.isString(message.ratio_percentage))
+                        return "ratio_percentage: string expected";
+                if (message.enable != null && message.hasOwnProperty("enable"))
+                    if (typeof message.enable !== "boolean")
+                        return "enable: boolean expected";
+                return null;
+            };
+    
+            /**
+             * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.NormalAskSetting} NormalAskSetting
+             */
+            NormalAskSetting.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.NormalAskSetting)
+                    return object;
+                var message = new $root.main.NormalAskSetting();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.price_ujpy != null)
+                    message.price_ujpy = String(object.price_ujpy);
+                if (object.amount_uupx != null)
+                    message.amount_uupx = String(object.amount_uupx);
+                if (object.ratio_percentage != null)
+                    message.ratio_percentage = String(object.ratio_percentage);
+                if (object.enable != null)
+                    message.enable = Boolean(object.enable);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.NormalAskSetting
+             * @static
+             * @param {main.NormalAskSetting} message NormalAskSetting
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            NormalAskSetting.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.price_ujpy = "";
+                    object.amount_uupx = "";
+                    object.ratio_percentage = "";
+                    object.enable = false;
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    object.price_ujpy = message.price_ujpy;
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    object.amount_uupx = message.amount_uupx;
+                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                    object.ratio_percentage = message.ratio_percentage;
+                if (message.enable != null && message.hasOwnProperty("enable"))
+                    object.enable = message.enable;
+                return object;
+            };
+    
+            /**
+             * Converts this NormalAskSetting to JSON.
+             * @function toJSON
+             * @memberof main.NormalAskSetting
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            NormalAskSetting.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return NormalAskSetting;
+        })();
+    
         main.NormalBidDelete = (function() {
     
             /**
@@ -7536,6 +7250,292 @@
             };
     
             return NormalBidDelete;
+        })();
+    
+        main.NormalBidHistory = (function() {
+    
+            /**
+             * Properties of a NormalBidHistory.
+             * @memberof main
+             * @interface INormalBidHistory
+             * @property {string|null} [id] NormalBidHistory id
+             * @property {string|null} [account_id] NormalBidHistory account_id
+             * @property {string|null} [price_ujpy] NormalBidHistory price_ujpy
+             * @property {string|null} [amount_uupx] NormalBidHistory amount_uupx
+             * @property {boolean|null} [is_accepted] NormalBidHistory is_accepted
+             * @property {string|null} [contract_price_ujpy] NormalBidHistory contract_price_ujpy
+             */
+    
+            /**
+             * Constructs a new NormalBidHistory.
+             * @memberof main
+             * @classdesc Represents a NormalBidHistory.
+             * @implements INormalBidHistory
+             * @constructor
+             * @param {main.INormalBidHistory=} [properties] Properties to set
+             */
+            function NormalBidHistory(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * NormalBidHistory id.
+             * @member {string} id
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.id = "";
+    
+            /**
+             * NormalBidHistory account_id.
+             * @member {string} account_id
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.account_id = "";
+    
+            /**
+             * NormalBidHistory price_ujpy.
+             * @member {string} price_ujpy
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.price_ujpy = "";
+    
+            /**
+             * NormalBidHistory amount_uupx.
+             * @member {string} amount_uupx
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.amount_uupx = "";
+    
+            /**
+             * NormalBidHistory is_accepted.
+             * @member {boolean} is_accepted
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.is_accepted = false;
+    
+            /**
+             * NormalBidHistory contract_price_ujpy.
+             * @member {string} contract_price_ujpy
+             * @memberof main.NormalBidHistory
+             * @instance
+             */
+            NormalBidHistory.prototype.contract_price_ujpy = "";
+    
+            /**
+             * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+             * @function encode
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            NormalBidHistory.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.account_id != null && Object.hasOwnProperty.call(message, "account_id"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.account_id);
+                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.price_ujpy);
+                if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uupx);
+                if (message.is_accepted != null && Object.hasOwnProperty.call(message, "is_accepted"))
+                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.is_accepted);
+                if (message.contract_price_ujpy != null && Object.hasOwnProperty.call(message, "contract_price_ujpy"))
+                    writer.uint32(/* id 6, wireType 2 =*/50).string(message.contract_price_ujpy);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            NormalBidHistory.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a NormalBidHistory message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.NormalBidHistory} NormalBidHistory
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            NormalBidHistory.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalBidHistory();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.account_id = reader.string();
+                        break;
+                    case 3:
+                        message.price_ujpy = reader.string();
+                        break;
+                    case 4:
+                        message.amount_uupx = reader.string();
+                        break;
+                    case 5:
+                        message.is_accepted = reader.bool();
+                        break;
+                    case 6:
+                        message.contract_price_ujpy = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.NormalBidHistory} NormalBidHistory
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            NormalBidHistory.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a NormalBidHistory message.
+             * @function verify
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            NormalBidHistory.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.account_id != null && message.hasOwnProperty("account_id"))
+                    if (!$util.isString(message.account_id))
+                        return "account_id: string expected";
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    if (!$util.isString(message.price_ujpy))
+                        return "price_ujpy: string expected";
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    if (!$util.isString(message.amount_uupx))
+                        return "amount_uupx: string expected";
+                if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
+                    if (typeof message.is_accepted !== "boolean")
+                        return "is_accepted: boolean expected";
+                if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
+                    if (!$util.isString(message.contract_price_ujpy))
+                        return "contract_price_ujpy: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.NormalBidHistory} NormalBidHistory
+             */
+            NormalBidHistory.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.NormalBidHistory)
+                    return object;
+                var message = new $root.main.NormalBidHistory();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.account_id != null)
+                    message.account_id = String(object.account_id);
+                if (object.price_ujpy != null)
+                    message.price_ujpy = String(object.price_ujpy);
+                if (object.amount_uupx != null)
+                    message.amount_uupx = String(object.amount_uupx);
+                if (object.is_accepted != null)
+                    message.is_accepted = Boolean(object.is_accepted);
+                if (object.contract_price_ujpy != null)
+                    message.contract_price_ujpy = String(object.contract_price_ujpy);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.NormalBidHistory
+             * @static
+             * @param {main.NormalBidHistory} message NormalBidHistory
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            NormalBidHistory.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.account_id = "";
+                    object.price_ujpy = "";
+                    object.amount_uupx = "";
+                    object.is_accepted = false;
+                    object.contract_price_ujpy = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.account_id != null && message.hasOwnProperty("account_id"))
+                    object.account_id = message.account_id;
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    object.price_ujpy = message.price_ujpy;
+                if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                    object.amount_uupx = message.amount_uupx;
+                if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
+                    object.is_accepted = message.is_accepted;
+                if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
+                    object.contract_price_ujpy = message.contract_price_ujpy;
+                return object;
+            };
+    
+            /**
+             * Converts this NormalBidHistory to JSON.
+             * @function toJSON
+             * @memberof main.NormalBidHistory
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            NormalBidHistory.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return NormalBidHistory;
         })();
     
         main.NormalBid = (function() {
@@ -8306,6 +8306,226 @@
             };
     
             return PrimaryAsk;
+        })();
+    
+        main.PrimaryAskSetting = (function() {
+    
+            /**
+             * Properties of a PrimaryAskSetting.
+             * @memberof main
+             * @interface IPrimaryAskSetting
+             * @property {string|null} [id] PrimaryAskSetting id
+             * @property {string|null} [price_ujpy] PrimaryAskSetting price_ujpy
+             * @property {string|null} [ratio_percentage] PrimaryAskSetting ratio_percentage
+             */
+    
+            /**
+             * Constructs a new PrimaryAskSetting.
+             * @memberof main
+             * @classdesc Represents a PrimaryAskSetting.
+             * @implements IPrimaryAskSetting
+             * @constructor
+             * @param {main.IPrimaryAskSetting=} [properties] Properties to set
+             */
+            function PrimaryAskSetting(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * PrimaryAskSetting id.
+             * @member {string} id
+             * @memberof main.PrimaryAskSetting
+             * @instance
+             */
+            PrimaryAskSetting.prototype.id = "";
+    
+            /**
+             * PrimaryAskSetting price_ujpy.
+             * @member {string} price_ujpy
+             * @memberof main.PrimaryAskSetting
+             * @instance
+             */
+            PrimaryAskSetting.prototype.price_ujpy = "";
+    
+            /**
+             * PrimaryAskSetting ratio_percentage.
+             * @member {string} ratio_percentage
+             * @memberof main.PrimaryAskSetting
+             * @instance
+             */
+            PrimaryAskSetting.prototype.ratio_percentage = "";
+    
+            /**
+             * Encodes the specified PrimaryAskSetting message. Does not implicitly {@link main.PrimaryAskSetting.verify|verify} messages.
+             * @function encode
+             * @memberof main.PrimaryAskSetting
+             * @static
+             * @param {main.IPrimaryAskSetting} message PrimaryAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            PrimaryAskSetting.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+                if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.ratio_percentage);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified PrimaryAskSetting message, length delimited. Does not implicitly {@link main.PrimaryAskSetting.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.PrimaryAskSetting
+             * @static
+             * @param {main.IPrimaryAskSetting} message PrimaryAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            PrimaryAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a PrimaryAskSetting message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.PrimaryAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.PrimaryAskSetting} PrimaryAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            PrimaryAskSetting.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.PrimaryAskSetting();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.price_ujpy = reader.string();
+                        break;
+                    case 3:
+                        message.ratio_percentage = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a PrimaryAskSetting message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.PrimaryAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.PrimaryAskSetting} PrimaryAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            PrimaryAskSetting.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a PrimaryAskSetting message.
+             * @function verify
+             * @memberof main.PrimaryAskSetting
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            PrimaryAskSetting.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    if (!$util.isString(message.price_ujpy))
+                        return "price_ujpy: string expected";
+                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                    if (!$util.isString(message.ratio_percentage))
+                        return "ratio_percentage: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a PrimaryAskSetting message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.PrimaryAskSetting
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.PrimaryAskSetting} PrimaryAskSetting
+             */
+            PrimaryAskSetting.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.PrimaryAskSetting)
+                    return object;
+                var message = new $root.main.PrimaryAskSetting();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.price_ujpy != null)
+                    message.price_ujpy = String(object.price_ujpy);
+                if (object.ratio_percentage != null)
+                    message.ratio_percentage = String(object.ratio_percentage);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a PrimaryAskSetting message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.PrimaryAskSetting
+             * @static
+             * @param {main.PrimaryAskSetting} message PrimaryAskSetting
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            PrimaryAskSetting.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.price_ujpy = "";
+                    object.ratio_percentage = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    object.price_ujpy = message.price_ujpy;
+                if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                    object.ratio_percentage = message.ratio_percentage;
+                return object;
+            };
+    
+            /**
+             * Converts this PrimaryAskSetting to JSON.
+             * @function toJSON
+             * @memberof main.PrimaryAskSetting
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            PrimaryAskSetting.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return PrimaryAskSetting;
         })();
     
         main.PrimaryBid = (function() {
@@ -9090,226 +9310,6 @@
             return RenewableAskHistory;
         })();
     
-        main.RenewableAskSetting = (function() {
-    
-            /**
-             * Properties of a RenewableAskSetting.
-             * @memberof main
-             * @interface IRenewableAskSetting
-             * @property {string|null} [id] RenewableAskSetting id
-             * @property {string|null} [price_ujpy] RenewableAskSetting price_ujpy
-             * @property {string|null} [amount_uspx] RenewableAskSetting amount_uspx
-             */
-    
-            /**
-             * Constructs a new RenewableAskSetting.
-             * @memberof main
-             * @classdesc Represents a RenewableAskSetting.
-             * @implements IRenewableAskSetting
-             * @constructor
-             * @param {main.IRenewableAskSetting=} [properties] Properties to set
-             */
-            function RenewableAskSetting(properties) {
-                if (properties)
-                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                        if (properties[keys[i]] != null)
-                            this[keys[i]] = properties[keys[i]];
-            }
-    
-            /**
-             * RenewableAskSetting id.
-             * @member {string} id
-             * @memberof main.RenewableAskSetting
-             * @instance
-             */
-            RenewableAskSetting.prototype.id = "";
-    
-            /**
-             * RenewableAskSetting price_ujpy.
-             * @member {string} price_ujpy
-             * @memberof main.RenewableAskSetting
-             * @instance
-             */
-            RenewableAskSetting.prototype.price_ujpy = "";
-    
-            /**
-             * RenewableAskSetting amount_uspx.
-             * @member {string} amount_uspx
-             * @memberof main.RenewableAskSetting
-             * @instance
-             */
-            RenewableAskSetting.prototype.amount_uspx = "";
-    
-            /**
-             * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-             * @function encode
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            RenewableAskSetting.encode = function encode(message, writer) {
-                if (!writer)
-                    writer = $Writer.create();
-                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
-                if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
-                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
-                return writer;
-            };
-    
-            /**
-             * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-             * @function encodeDelimited
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
-             * @param {$protobuf.Writer} [writer] Writer to encode to
-             * @returns {$protobuf.Writer} Writer
-             */
-            RenewableAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
-                return this.encode(message, writer).ldelim();
-            };
-    
-            /**
-             * Decodes a RenewableAskSetting message from the specified reader or buffer.
-             * @function decode
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @param {number} [length] Message length if known beforehand
-             * @returns {main.RenewableAskSetting} RenewableAskSetting
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            RenewableAskSetting.decode = function decode(reader, length) {
-                if (!(reader instanceof $Reader))
-                    reader = $Reader.create(reader);
-                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.RenewableAskSetting();
-                while (reader.pos < end) {
-                    var tag = reader.uint32();
-                    switch (tag >>> 3) {
-                    case 1:
-                        message.id = reader.string();
-                        break;
-                    case 2:
-                        message.price_ujpy = reader.string();
-                        break;
-                    case 3:
-                        message.amount_uspx = reader.string();
-                        break;
-                    default:
-                        reader.skipType(tag & 7);
-                        break;
-                    }
-                }
-                return message;
-            };
-    
-            /**
-             * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
-             * @function decodeDelimited
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-             * @returns {main.RenewableAskSetting} RenewableAskSetting
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            RenewableAskSetting.decodeDelimited = function decodeDelimited(reader) {
-                if (!(reader instanceof $Reader))
-                    reader = new $Reader(reader);
-                return this.decode(reader, reader.uint32());
-            };
-    
-            /**
-             * Verifies a RenewableAskSetting message.
-             * @function verify
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {Object.<string,*>} message Plain object to verify
-             * @returns {string|null} `null` if valid, otherwise the reason why it is not
-             */
-            RenewableAskSetting.verify = function verify(message) {
-                if (typeof message !== "object" || message === null)
-                    return "object expected";
-                if (message.id != null && message.hasOwnProperty("id"))
-                    if (!$util.isString(message.id))
-                        return "id: string expected";
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    if (!$util.isString(message.price_ujpy))
-                        return "price_ujpy: string expected";
-                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                    if (!$util.isString(message.amount_uspx))
-                        return "amount_uspx: string expected";
-                return null;
-            };
-    
-            /**
-             * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
-             * @function fromObject
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {Object.<string,*>} object Plain object
-             * @returns {main.RenewableAskSetting} RenewableAskSetting
-             */
-            RenewableAskSetting.fromObject = function fromObject(object) {
-                if (object instanceof $root.main.RenewableAskSetting)
-                    return object;
-                var message = new $root.main.RenewableAskSetting();
-                if (object.id != null)
-                    message.id = String(object.id);
-                if (object.price_ujpy != null)
-                    message.price_ujpy = String(object.price_ujpy);
-                if (object.amount_uspx != null)
-                    message.amount_uspx = String(object.amount_uspx);
-                return message;
-            };
-    
-            /**
-             * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
-             * @function toObject
-             * @memberof main.RenewableAskSetting
-             * @static
-             * @param {main.RenewableAskSetting} message RenewableAskSetting
-             * @param {$protobuf.IConversionOptions} [options] Conversion options
-             * @returns {Object.<string,*>} Plain object
-             */
-            RenewableAskSetting.toObject = function toObject(message, options) {
-                if (!options)
-                    options = {};
-                var object = {};
-                if (options.defaults) {
-                    object.id = "";
-                    object.price_ujpy = "";
-                    object.amount_uspx = "";
-                }
-                if (message.id != null && message.hasOwnProperty("id"))
-                    object.id = message.id;
-                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                    object.price_ujpy = message.price_ujpy;
-                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                    object.amount_uspx = message.amount_uspx;
-                return object;
-            };
-    
-            /**
-             * Converts this RenewableAskSetting to JSON.
-             * @function toJSON
-             * @memberof main.RenewableAskSetting
-             * @instance
-             * @returns {Object.<string,*>} JSON object
-             */
-            RenewableAskSetting.prototype.toJSON = function toJSON() {
-                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-            };
-    
-            return RenewableAskSetting;
-        })();
-    
         /**
          * RenewableAskType enum.
          * @name main.RenewableAskType
@@ -9628,6 +9628,226 @@
             };
     
             return RenewableAsk;
+        })();
+    
+        main.RenewableAskSetting = (function() {
+    
+            /**
+             * Properties of a RenewableAskSetting.
+             * @memberof main
+             * @interface IRenewableAskSetting
+             * @property {string|null} [id] RenewableAskSetting id
+             * @property {string|null} [price_ujpy] RenewableAskSetting price_ujpy
+             * @property {string|null} [amount_uspx] RenewableAskSetting amount_uspx
+             */
+    
+            /**
+             * Constructs a new RenewableAskSetting.
+             * @memberof main
+             * @classdesc Represents a RenewableAskSetting.
+             * @implements IRenewableAskSetting
+             * @constructor
+             * @param {main.IRenewableAskSetting=} [properties] Properties to set
+             */
+            function RenewableAskSetting(properties) {
+                if (properties)
+                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                        if (properties[keys[i]] != null)
+                            this[keys[i]] = properties[keys[i]];
+            }
+    
+            /**
+             * RenewableAskSetting id.
+             * @member {string} id
+             * @memberof main.RenewableAskSetting
+             * @instance
+             */
+            RenewableAskSetting.prototype.id = "";
+    
+            /**
+             * RenewableAskSetting price_ujpy.
+             * @member {string} price_ujpy
+             * @memberof main.RenewableAskSetting
+             * @instance
+             */
+            RenewableAskSetting.prototype.price_ujpy = "";
+    
+            /**
+             * RenewableAskSetting amount_uspx.
+             * @member {string} amount_uspx
+             * @memberof main.RenewableAskSetting
+             * @instance
+             */
+            RenewableAskSetting.prototype.amount_uspx = "";
+    
+            /**
+             * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+             * @function encode
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            RenewableAskSetting.encode = function encode(message, writer) {
+                if (!writer)
+                    writer = $Writer.create();
+                if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+                if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+                if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
+                return writer;
+            };
+    
+            /**
+             * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+             * @function encodeDelimited
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
+             * @param {$protobuf.Writer} [writer] Writer to encode to
+             * @returns {$protobuf.Writer} Writer
+             */
+            RenewableAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+                return this.encode(message, writer).ldelim();
+            };
+    
+            /**
+             * Decodes a RenewableAskSetting message from the specified reader or buffer.
+             * @function decode
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @param {number} [length] Message length if known beforehand
+             * @returns {main.RenewableAskSetting} RenewableAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            RenewableAskSetting.decode = function decode(reader, length) {
+                if (!(reader instanceof $Reader))
+                    reader = $Reader.create(reader);
+                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.RenewableAskSetting();
+                while (reader.pos < end) {
+                    var tag = reader.uint32();
+                    switch (tag >>> 3) {
+                    case 1:
+                        message.id = reader.string();
+                        break;
+                    case 2:
+                        message.price_ujpy = reader.string();
+                        break;
+                    case 3:
+                        message.amount_uspx = reader.string();
+                        break;
+                    default:
+                        reader.skipType(tag & 7);
+                        break;
+                    }
+                }
+                return message;
+            };
+    
+            /**
+             * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
+             * @function decodeDelimited
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+             * @returns {main.RenewableAskSetting} RenewableAskSetting
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            RenewableAskSetting.decodeDelimited = function decodeDelimited(reader) {
+                if (!(reader instanceof $Reader))
+                    reader = new $Reader(reader);
+                return this.decode(reader, reader.uint32());
+            };
+    
+            /**
+             * Verifies a RenewableAskSetting message.
+             * @function verify
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {Object.<string,*>} message Plain object to verify
+             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+             */
+            RenewableAskSetting.verify = function verify(message) {
+                if (typeof message !== "object" || message === null)
+                    return "object expected";
+                if (message.id != null && message.hasOwnProperty("id"))
+                    if (!$util.isString(message.id))
+                        return "id: string expected";
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    if (!$util.isString(message.price_ujpy))
+                        return "price_ujpy: string expected";
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    if (!$util.isString(message.amount_uspx))
+                        return "amount_uspx: string expected";
+                return null;
+            };
+    
+            /**
+             * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
+             * @function fromObject
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {Object.<string,*>} object Plain object
+             * @returns {main.RenewableAskSetting} RenewableAskSetting
+             */
+            RenewableAskSetting.fromObject = function fromObject(object) {
+                if (object instanceof $root.main.RenewableAskSetting)
+                    return object;
+                var message = new $root.main.RenewableAskSetting();
+                if (object.id != null)
+                    message.id = String(object.id);
+                if (object.price_ujpy != null)
+                    message.price_ujpy = String(object.price_ujpy);
+                if (object.amount_uspx != null)
+                    message.amount_uspx = String(object.amount_uspx);
+                return message;
+            };
+    
+            /**
+             * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
+             * @function toObject
+             * @memberof main.RenewableAskSetting
+             * @static
+             * @param {main.RenewableAskSetting} message RenewableAskSetting
+             * @param {$protobuf.IConversionOptions} [options] Conversion options
+             * @returns {Object.<string,*>} Plain object
+             */
+            RenewableAskSetting.toObject = function toObject(message, options) {
+                if (!options)
+                    options = {};
+                var object = {};
+                if (options.defaults) {
+                    object.id = "";
+                    object.price_ujpy = "";
+                    object.amount_uspx = "";
+                }
+                if (message.id != null && message.hasOwnProperty("id"))
+                    object.id = message.id;
+                if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                    object.price_ujpy = message.price_ujpy;
+                if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                    object.amount_uspx = message.amount_uspx;
+                return object;
+            };
+    
+            /**
+             * Converts this RenewableAskSetting to JSON.
+             * @function toJSON
+             * @memberof main.RenewableAskSetting
+             * @instance
+             * @returns {Object.<string,*>} JSON object
+             */
+            RenewableAskSetting.prototype.toJSON = function toJSON() {
+                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+            };
+    
+            return RenewableAskSetting;
         })();
     
         main.RenewableBidDelete = (function() {

--- a/common/src/proto.d.ts
+++ b/common/src/proto.d.ts
@@ -2,6 +2,101 @@ import * as $protobuf from "protobufjs";
 /** Namespace main. */
 export namespace main {
 
+    /** Properties of an AccountantAccount. */
+    interface IAccountantAccount {
+
+        /** AccountantAccount id */
+        id?: (string|null);
+
+        /** AccountantAccount name */
+        name?: (string|null);
+
+        /** AccountantAccount xrp_address */
+        xrp_address?: (string|null);
+    }
+
+    /** Represents an AccountantAccount. */
+    class AccountantAccount implements IAccountantAccount {
+
+        /**
+         * Constructs a new AccountantAccount.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.IAccountantAccount);
+
+        /** AccountantAccount id. */
+        public id: string;
+
+        /** AccountantAccount name. */
+        public name: string;
+
+        /** AccountantAccount xrp_address. */
+        public xrp_address: string;
+
+        /**
+         * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+         * @param message AccountantAccount message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.IAccountantAccount, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+         * @param message AccountantAccount message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.IAccountantAccount, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes an AccountantAccount message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns AccountantAccount
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.AccountantAccount;
+
+        /**
+         * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns AccountantAccount
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.AccountantAccount;
+
+        /**
+         * Verifies an AccountantAccount message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns AccountantAccount
+         */
+        public static fromObject(object: { [k: string]: any }): main.AccountantAccount;
+
+        /**
+         * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
+         * @param message AccountantAccount
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.AccountantAccount, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this AccountantAccount to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
     /** Properties of an AccountPrivate. */
     interface IAccountPrivate {
 
@@ -98,101 +193,6 @@ export namespace main {
 
         /**
          * Converts this AccountPrivate to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
-    /** Properties of an AccountantAccount. */
-    interface IAccountantAccount {
-
-        /** AccountantAccount id */
-        id?: (string|null);
-
-        /** AccountantAccount name */
-        name?: (string|null);
-
-        /** AccountantAccount xrp_address */
-        xrp_address?: (string|null);
-    }
-
-    /** Represents an AccountantAccount. */
-    class AccountantAccount implements IAccountantAccount {
-
-        /**
-         * Constructs a new AccountantAccount.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.IAccountantAccount);
-
-        /** AccountantAccount id. */
-        public id: string;
-
-        /** AccountantAccount name. */
-        public name: string;
-
-        /** AccountantAccount xrp_address. */
-        public xrp_address: string;
-
-        /**
-         * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-         * @param message AccountantAccount message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.IAccountantAccount, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-         * @param message AccountantAccount message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.IAccountantAccount, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes an AccountantAccount message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns AccountantAccount
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.AccountantAccount;
-
-        /**
-         * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns AccountantAccount
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.AccountantAccount;
-
-        /**
-         * Verifies an AccountantAccount message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns AccountantAccount
-         */
-        public static fromObject(object: { [k: string]: any }): main.AccountantAccount;
-
-        /**
-         * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
-         * @param message AccountantAccount
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.AccountantAccount, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this AccountantAccount to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
@@ -622,107 +622,6 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a BalanceSnapshot. */
-    interface IBalanceSnapshot {
-
-        /** BalanceSnapshot id */
-        id?: (string|null);
-
-        /** BalanceSnapshot student_account_id */
-        student_account_id?: (string|null);
-
-        /** BalanceSnapshot amount_uupx */
-        amount_uupx?: (string|null);
-
-        /** BalanceSnapshot amount_uspx */
-        amount_uspx?: (string|null);
-    }
-
-    /** Represents a BalanceSnapshot. */
-    class BalanceSnapshot implements IBalanceSnapshot {
-
-        /**
-         * Constructs a new BalanceSnapshot.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.IBalanceSnapshot);
-
-        /** BalanceSnapshot id. */
-        public id: string;
-
-        /** BalanceSnapshot student_account_id. */
-        public student_account_id: string;
-
-        /** BalanceSnapshot amount_uupx. */
-        public amount_uupx: string;
-
-        /** BalanceSnapshot amount_uspx. */
-        public amount_uspx: string;
-
-        /**
-         * Encodes the specified BalanceSnapshot message. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
-         * @param message BalanceSnapshot message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.IBalanceSnapshot, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified BalanceSnapshot message, length delimited. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
-         * @param message BalanceSnapshot message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.IBalanceSnapshot, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a BalanceSnapshot message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns BalanceSnapshot
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.BalanceSnapshot;
-
-        /**
-         * Decodes a BalanceSnapshot message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns BalanceSnapshot
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.BalanceSnapshot;
-
-        /**
-         * Verifies a BalanceSnapshot message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a BalanceSnapshot message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns BalanceSnapshot
-         */
-        public static fromObject(object: { [k: string]: any }): main.BalanceSnapshot;
-
-        /**
-         * Creates a plain object from a BalanceSnapshot message. Also converts values to other types if specified.
-         * @param message BalanceSnapshot
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.BalanceSnapshot, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this BalanceSnapshot to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
     /** Properties of a Balance. */
     interface IBalance {
 
@@ -819,6 +718,107 @@ export namespace main {
 
         /**
          * Converts this Balance to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a BalanceSnapshot. */
+    interface IBalanceSnapshot {
+
+        /** BalanceSnapshot id */
+        id?: (string|null);
+
+        /** BalanceSnapshot student_account_id */
+        student_account_id?: (string|null);
+
+        /** BalanceSnapshot amount_uupx */
+        amount_uupx?: (string|null);
+
+        /** BalanceSnapshot amount_uspx */
+        amount_uspx?: (string|null);
+    }
+
+    /** Represents a BalanceSnapshot. */
+    class BalanceSnapshot implements IBalanceSnapshot {
+
+        /**
+         * Constructs a new BalanceSnapshot.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.IBalanceSnapshot);
+
+        /** BalanceSnapshot id. */
+        public id: string;
+
+        /** BalanceSnapshot student_account_id. */
+        public student_account_id: string;
+
+        /** BalanceSnapshot amount_uupx. */
+        public amount_uupx: string;
+
+        /** BalanceSnapshot amount_uspx. */
+        public amount_uspx: string;
+
+        /**
+         * Encodes the specified BalanceSnapshot message. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
+         * @param message BalanceSnapshot message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.IBalanceSnapshot, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified BalanceSnapshot message, length delimited. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
+         * @param message BalanceSnapshot message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.IBalanceSnapshot, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a BalanceSnapshot message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns BalanceSnapshot
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.BalanceSnapshot;
+
+        /**
+         * Decodes a BalanceSnapshot message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns BalanceSnapshot
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.BalanceSnapshot;
+
+        /**
+         * Verifies a BalanceSnapshot message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a BalanceSnapshot message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns BalanceSnapshot
+         */
+        public static fromObject(object: { [k: string]: any }): main.BalanceSnapshot;
+
+        /**
+         * Creates a plain object from a BalanceSnapshot message. Also converts values to other types if specified.
+         * @param message BalanceSnapshot
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.BalanceSnapshot, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this BalanceSnapshot to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
@@ -2494,119 +2494,6 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a NormalBidHistory. */
-    interface INormalBidHistory {
-
-        /** NormalBidHistory id */
-        id?: (string|null);
-
-        /** NormalBidHistory account_id */
-        account_id?: (string|null);
-
-        /** NormalBidHistory price_ujpy */
-        price_ujpy?: (string|null);
-
-        /** NormalBidHistory amount_uupx */
-        amount_uupx?: (string|null);
-
-        /** NormalBidHistory is_accepted */
-        is_accepted?: (boolean|null);
-
-        /** NormalBidHistory contract_price_ujpy */
-        contract_price_ujpy?: (string|null);
-    }
-
-    /** Represents a NormalBidHistory. */
-    class NormalBidHistory implements INormalBidHistory {
-
-        /**
-         * Constructs a new NormalBidHistory.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.INormalBidHistory);
-
-        /** NormalBidHistory id. */
-        public id: string;
-
-        /** NormalBidHistory account_id. */
-        public account_id: string;
-
-        /** NormalBidHistory price_ujpy. */
-        public price_ujpy: string;
-
-        /** NormalBidHistory amount_uupx. */
-        public amount_uupx: string;
-
-        /** NormalBidHistory is_accepted. */
-        public is_accepted: boolean;
-
-        /** NormalBidHistory contract_price_ujpy. */
-        public contract_price_ujpy: string;
-
-        /**
-         * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-         * @param message NormalBidHistory message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.INormalBidHistory, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-         * @param message NormalBidHistory message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.INormalBidHistory, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a NormalBidHistory message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns NormalBidHistory
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.NormalBidHistory;
-
-        /**
-         * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns NormalBidHistory
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.NormalBidHistory;
-
-        /**
-         * Verifies a NormalBidHistory message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns NormalBidHistory
-         */
-        public static fromObject(object: { [k: string]: any }): main.NormalBidHistory;
-
-        /**
-         * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
-         * @param message NormalBidHistory
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.NormalBidHistory, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this NormalBidHistory to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
     /** NormalAskHistoryType enum. */
     enum NormalAskHistoryType {
         UNKNOWN = 0,
@@ -2733,113 +2620,6 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a NormalAskSetting. */
-    interface INormalAskSetting {
-
-        /** NormalAskSetting id */
-        id?: (string|null);
-
-        /** NormalAskSetting price_ujpy */
-        price_ujpy?: (string|null);
-
-        /** NormalAskSetting amount_uupx */
-        amount_uupx?: (string|null);
-
-        /** NormalAskSetting ratio_percentage */
-        ratio_percentage?: (string|null);
-
-        /** NormalAskSetting enable */
-        enable?: (boolean|null);
-    }
-
-    /** Represents a NormalAskSetting. */
-    class NormalAskSetting implements INormalAskSetting {
-
-        /**
-         * Constructs a new NormalAskSetting.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.INormalAskSetting);
-
-        /** NormalAskSetting id. */
-        public id: string;
-
-        /** NormalAskSetting price_ujpy. */
-        public price_ujpy: string;
-
-        /** NormalAskSetting amount_uupx. */
-        public amount_uupx: string;
-
-        /** NormalAskSetting ratio_percentage. */
-        public ratio_percentage: string;
-
-        /** NormalAskSetting enable. */
-        public enable: boolean;
-
-        /**
-         * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-         * @param message NormalAskSetting message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.INormalAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-         * @param message NormalAskSetting message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.INormalAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a NormalAskSetting message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns NormalAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.NormalAskSetting;
-
-        /**
-         * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns NormalAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.NormalAskSetting;
-
-        /**
-         * Verifies a NormalAskSetting message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns NormalAskSetting
-         */
-        public static fromObject(object: { [k: string]: any }): main.NormalAskSetting;
-
-        /**
-         * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
-         * @param message NormalAskSetting
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.NormalAskSetting, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this NormalAskSetting to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
     /** NormalAskType enum. */
     enum NormalAskType {
         UNKNOWN = 0,
@@ -2960,6 +2740,113 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
+    /** Properties of a NormalAskSetting. */
+    interface INormalAskSetting {
+
+        /** NormalAskSetting id */
+        id?: (string|null);
+
+        /** NormalAskSetting price_ujpy */
+        price_ujpy?: (string|null);
+
+        /** NormalAskSetting amount_uupx */
+        amount_uupx?: (string|null);
+
+        /** NormalAskSetting ratio_percentage */
+        ratio_percentage?: (string|null);
+
+        /** NormalAskSetting enable */
+        enable?: (boolean|null);
+    }
+
+    /** Represents a NormalAskSetting. */
+    class NormalAskSetting implements INormalAskSetting {
+
+        /**
+         * Constructs a new NormalAskSetting.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.INormalAskSetting);
+
+        /** NormalAskSetting id. */
+        public id: string;
+
+        /** NormalAskSetting price_ujpy. */
+        public price_ujpy: string;
+
+        /** NormalAskSetting amount_uupx. */
+        public amount_uupx: string;
+
+        /** NormalAskSetting ratio_percentage. */
+        public ratio_percentage: string;
+
+        /** NormalAskSetting enable. */
+        public enable: boolean;
+
+        /**
+         * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+         * @param message NormalAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.INormalAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+         * @param message NormalAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.INormalAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a NormalAskSetting message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns NormalAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.NormalAskSetting;
+
+        /**
+         * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns NormalAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.NormalAskSetting;
+
+        /**
+         * Verifies a NormalAskSetting message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns NormalAskSetting
+         */
+        public static fromObject(object: { [k: string]: any }): main.NormalAskSetting;
+
+        /**
+         * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
+         * @param message NormalAskSetting
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.NormalAskSetting, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this NormalAskSetting to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
     /** Properties of a NormalBidDelete. */
     interface INormalBidDelete {
 
@@ -3044,6 +2931,119 @@ export namespace main {
 
         /**
          * Converts this NormalBidDelete to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a NormalBidHistory. */
+    interface INormalBidHistory {
+
+        /** NormalBidHistory id */
+        id?: (string|null);
+
+        /** NormalBidHistory account_id */
+        account_id?: (string|null);
+
+        /** NormalBidHistory price_ujpy */
+        price_ujpy?: (string|null);
+
+        /** NormalBidHistory amount_uupx */
+        amount_uupx?: (string|null);
+
+        /** NormalBidHistory is_accepted */
+        is_accepted?: (boolean|null);
+
+        /** NormalBidHistory contract_price_ujpy */
+        contract_price_ujpy?: (string|null);
+    }
+
+    /** Represents a NormalBidHistory. */
+    class NormalBidHistory implements INormalBidHistory {
+
+        /**
+         * Constructs a new NormalBidHistory.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.INormalBidHistory);
+
+        /** NormalBidHistory id. */
+        public id: string;
+
+        /** NormalBidHistory account_id. */
+        public account_id: string;
+
+        /** NormalBidHistory price_ujpy. */
+        public price_ujpy: string;
+
+        /** NormalBidHistory amount_uupx. */
+        public amount_uupx: string;
+
+        /** NormalBidHistory is_accepted. */
+        public is_accepted: boolean;
+
+        /** NormalBidHistory contract_price_ujpy. */
+        public contract_price_ujpy: string;
+
+        /**
+         * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+         * @param message NormalBidHistory message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.INormalBidHistory, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+         * @param message NormalBidHistory message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.INormalBidHistory, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a NormalBidHistory message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns NormalBidHistory
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.NormalBidHistory;
+
+        /**
+         * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns NormalBidHistory
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.NormalBidHistory;
+
+        /**
+         * Verifies a NormalBidHistory message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns NormalBidHistory
+         */
+        public static fromObject(object: { [k: string]: any }): main.NormalBidHistory;
+
+        /**
+         * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
+         * @param message NormalBidHistory
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.NormalBidHistory, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this NormalBidHistory to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
@@ -3359,6 +3359,101 @@ export namespace main {
 
         /**
          * Converts this PrimaryAsk to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a PrimaryAskSetting. */
+    interface IPrimaryAskSetting {
+
+        /** PrimaryAskSetting id */
+        id?: (string|null);
+
+        /** PrimaryAskSetting price_ujpy */
+        price_ujpy?: (string|null);
+
+        /** PrimaryAskSetting ratio_percentage */
+        ratio_percentage?: (string|null);
+    }
+
+    /** Represents a PrimaryAskSetting. */
+    class PrimaryAskSetting implements IPrimaryAskSetting {
+
+        /**
+         * Constructs a new PrimaryAskSetting.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.IPrimaryAskSetting);
+
+        /** PrimaryAskSetting id. */
+        public id: string;
+
+        /** PrimaryAskSetting price_ujpy. */
+        public price_ujpy: string;
+
+        /** PrimaryAskSetting ratio_percentage. */
+        public ratio_percentage: string;
+
+        /**
+         * Encodes the specified PrimaryAskSetting message. Does not implicitly {@link main.PrimaryAskSetting.verify|verify} messages.
+         * @param message PrimaryAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.IPrimaryAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified PrimaryAskSetting message, length delimited. Does not implicitly {@link main.PrimaryAskSetting.verify|verify} messages.
+         * @param message PrimaryAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.IPrimaryAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a PrimaryAskSetting message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns PrimaryAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.PrimaryAskSetting;
+
+        /**
+         * Decodes a PrimaryAskSetting message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns PrimaryAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.PrimaryAskSetting;
+
+        /**
+         * Verifies a PrimaryAskSetting message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a PrimaryAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns PrimaryAskSetting
+         */
+        public static fromObject(object: { [k: string]: any }): main.PrimaryAskSetting;
+
+        /**
+         * Creates a plain object from a PrimaryAskSetting message. Also converts values to other types if specified.
+         * @param message PrimaryAskSetting
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.PrimaryAskSetting, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this PrimaryAskSetting to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };
@@ -3680,101 +3775,6 @@ export namespace main {
         public toJSON(): { [k: string]: any };
     }
 
-    /** Properties of a RenewableAskSetting. */
-    interface IRenewableAskSetting {
-
-        /** RenewableAskSetting id */
-        id?: (string|null);
-
-        /** RenewableAskSetting price_ujpy */
-        price_ujpy?: (string|null);
-
-        /** RenewableAskSetting amount_uspx */
-        amount_uspx?: (string|null);
-    }
-
-    /** Represents a RenewableAskSetting. */
-    class RenewableAskSetting implements IRenewableAskSetting {
-
-        /**
-         * Constructs a new RenewableAskSetting.
-         * @param [properties] Properties to set
-         */
-        constructor(properties?: main.IRenewableAskSetting);
-
-        /** RenewableAskSetting id. */
-        public id: string;
-
-        /** RenewableAskSetting price_ujpy. */
-        public price_ujpy: string;
-
-        /** RenewableAskSetting amount_uspx. */
-        public amount_uspx: string;
-
-        /**
-         * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-         * @param message RenewableAskSetting message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encode(message: main.IRenewableAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-         * @param message RenewableAskSetting message or plain object to encode
-         * @param [writer] Writer to encode to
-         * @returns Writer
-         */
-        public static encodeDelimited(message: main.IRenewableAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
-
-        /**
-         * Decodes a RenewableAskSetting message from the specified reader or buffer.
-         * @param reader Reader or buffer to decode from
-         * @param [length] Message length if known beforehand
-         * @returns RenewableAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.RenewableAskSetting;
-
-        /**
-         * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
-         * @param reader Reader or buffer to decode from
-         * @returns RenewableAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.RenewableAskSetting;
-
-        /**
-         * Verifies a RenewableAskSetting message.
-         * @param message Plain object to verify
-         * @returns `null` if valid, otherwise the reason why it is not
-         */
-        public static verify(message: { [k: string]: any }): (string|null);
-
-        /**
-         * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
-         * @param object Plain object
-         * @returns RenewableAskSetting
-         */
-        public static fromObject(object: { [k: string]: any }): main.RenewableAskSetting;
-
-        /**
-         * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
-         * @param message RenewableAskSetting
-         * @param [options] Conversion options
-         * @returns Plain object
-         */
-        public static toObject(message: main.RenewableAskSetting, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-        /**
-         * Converts this RenewableAskSetting to JSON.
-         * @returns JSON object
-         */
-        public toJSON(): { [k: string]: any };
-    }
-
     /** RenewableAskType enum. */
     enum RenewableAskType {
         UNKNOWN = 0,
@@ -3890,6 +3890,101 @@ export namespace main {
 
         /**
          * Converts this RenewableAsk to JSON.
+         * @returns JSON object
+         */
+        public toJSON(): { [k: string]: any };
+    }
+
+    /** Properties of a RenewableAskSetting. */
+    interface IRenewableAskSetting {
+
+        /** RenewableAskSetting id */
+        id?: (string|null);
+
+        /** RenewableAskSetting price_ujpy */
+        price_ujpy?: (string|null);
+
+        /** RenewableAskSetting amount_uspx */
+        amount_uspx?: (string|null);
+    }
+
+    /** Represents a RenewableAskSetting. */
+    class RenewableAskSetting implements IRenewableAskSetting {
+
+        /**
+         * Constructs a new RenewableAskSetting.
+         * @param [properties] Properties to set
+         */
+        constructor(properties?: main.IRenewableAskSetting);
+
+        /** RenewableAskSetting id. */
+        public id: string;
+
+        /** RenewableAskSetting price_ujpy. */
+        public price_ujpy: string;
+
+        /** RenewableAskSetting amount_uspx. */
+        public amount_uspx: string;
+
+        /**
+         * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+         * @param message RenewableAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encode(message: main.IRenewableAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+         * @param message RenewableAskSetting message or plain object to encode
+         * @param [writer] Writer to encode to
+         * @returns Writer
+         */
+        public static encodeDelimited(message: main.IRenewableAskSetting, writer?: $protobuf.Writer): $protobuf.Writer;
+
+        /**
+         * Decodes a RenewableAskSetting message from the specified reader or buffer.
+         * @param reader Reader or buffer to decode from
+         * @param [length] Message length if known beforehand
+         * @returns RenewableAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): main.RenewableAskSetting;
+
+        /**
+         * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
+         * @param reader Reader or buffer to decode from
+         * @returns RenewableAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): main.RenewableAskSetting;
+
+        /**
+         * Verifies a RenewableAskSetting message.
+         * @param message Plain object to verify
+         * @returns `null` if valid, otherwise the reason why it is not
+         */
+        public static verify(message: { [k: string]: any }): (string|null);
+
+        /**
+         * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @param object Plain object
+         * @returns RenewableAskSetting
+         */
+        public static fromObject(object: { [k: string]: any }): main.RenewableAskSetting;
+
+        /**
+         * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
+         * @param message RenewableAskSetting
+         * @param [options] Conversion options
+         * @returns Plain object
+         */
+        public static toObject(message: main.RenewableAskSetting, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+        /**
+         * Converts this RenewableAskSetting to JSON.
          * @returns JSON object
          */
         public toJSON(): { [k: string]: any };

--- a/common/src/proto.js
+++ b/common/src/proto.js
@@ -16,6 +16,226 @@ export const main = $root.main = (() => {
      */
     const main = {};
 
+    main.AccountantAccount = (function() {
+
+        /**
+         * Properties of an AccountantAccount.
+         * @memberof main
+         * @interface IAccountantAccount
+         * @property {string|null} [id] AccountantAccount id
+         * @property {string|null} [name] AccountantAccount name
+         * @property {string|null} [xrp_address] AccountantAccount xrp_address
+         */
+
+        /**
+         * Constructs a new AccountantAccount.
+         * @memberof main
+         * @classdesc Represents an AccountantAccount.
+         * @implements IAccountantAccount
+         * @constructor
+         * @param {main.IAccountantAccount=} [properties] Properties to set
+         */
+        function AccountantAccount(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * AccountantAccount id.
+         * @member {string} id
+         * @memberof main.AccountantAccount
+         * @instance
+         */
+        AccountantAccount.prototype.id = "";
+
+        /**
+         * AccountantAccount name.
+         * @member {string} name
+         * @memberof main.AccountantAccount
+         * @instance
+         */
+        AccountantAccount.prototype.name = "";
+
+        /**
+         * AccountantAccount xrp_address.
+         * @member {string} xrp_address
+         * @memberof main.AccountantAccount
+         * @instance
+         */
+        AccountantAccount.prototype.xrp_address = "";
+
+        /**
+         * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+         * @function encode
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AccountantAccount.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.name);
+            if (message.xrp_address != null && Object.hasOwnProperty.call(message, "xrp_address"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.xrp_address);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        AccountantAccount.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an AccountantAccount message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.AccountantAccount} AccountantAccount
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AccountantAccount.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.AccountantAccount();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.name = reader.string();
+                    break;
+                case 3:
+                    message.xrp_address = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.AccountantAccount} AccountantAccount
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        AccountantAccount.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an AccountantAccount message.
+         * @function verify
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        AccountantAccount.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.name != null && message.hasOwnProperty("name"))
+                if (!$util.isString(message.name))
+                    return "name: string expected";
+            if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
+                if (!$util.isString(message.xrp_address))
+                    return "xrp_address: string expected";
+            return null;
+        };
+
+        /**
+         * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.AccountantAccount} AccountantAccount
+         */
+        AccountantAccount.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.AccountantAccount)
+                return object;
+            let message = new $root.main.AccountantAccount();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.name != null)
+                message.name = String(object.name);
+            if (object.xrp_address != null)
+                message.xrp_address = String(object.xrp_address);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.AccountantAccount
+         * @static
+         * @param {main.AccountantAccount} message AccountantAccount
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        AccountantAccount.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.name = "";
+                object.xrp_address = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.name != null && message.hasOwnProperty("name"))
+                object.name = message.name;
+            if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
+                object.xrp_address = message.xrp_address;
+            return object;
+        };
+
+        /**
+         * Converts this AccountantAccount to JSON.
+         * @function toJSON
+         * @memberof main.AccountantAccount
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        AccountantAccount.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return AccountantAccount;
+    })();
+
     main.AccountPrivate = (function() {
 
         /**
@@ -256,226 +476,6 @@ export const main = $root.main = (() => {
         };
 
         return AccountPrivate;
-    })();
-
-    main.AccountantAccount = (function() {
-
-        /**
-         * Properties of an AccountantAccount.
-         * @memberof main
-         * @interface IAccountantAccount
-         * @property {string|null} [id] AccountantAccount id
-         * @property {string|null} [name] AccountantAccount name
-         * @property {string|null} [xrp_address] AccountantAccount xrp_address
-         */
-
-        /**
-         * Constructs a new AccountantAccount.
-         * @memberof main
-         * @classdesc Represents an AccountantAccount.
-         * @implements IAccountantAccount
-         * @constructor
-         * @param {main.IAccountantAccount=} [properties] Properties to set
-         */
-        function AccountantAccount(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * AccountantAccount id.
-         * @member {string} id
-         * @memberof main.AccountantAccount
-         * @instance
-         */
-        AccountantAccount.prototype.id = "";
-
-        /**
-         * AccountantAccount name.
-         * @member {string} name
-         * @memberof main.AccountantAccount
-         * @instance
-         */
-        AccountantAccount.prototype.name = "";
-
-        /**
-         * AccountantAccount xrp_address.
-         * @member {string} xrp_address
-         * @memberof main.AccountantAccount
-         * @instance
-         */
-        AccountantAccount.prototype.xrp_address = "";
-
-        /**
-         * Encodes the specified AccountantAccount message. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-         * @function encode
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        AccountantAccount.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.name != null && Object.hasOwnProperty.call(message, "name"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.name);
-            if (message.xrp_address != null && Object.hasOwnProperty.call(message, "xrp_address"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.xrp_address);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified AccountantAccount message, length delimited. Does not implicitly {@link main.AccountantAccount.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {main.IAccountantAccount} message AccountantAccount message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        AccountantAccount.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes an AccountantAccount message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.AccountantAccount} AccountantAccount
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        AccountantAccount.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.AccountantAccount();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.name = reader.string();
-                    break;
-                case 3:
-                    message.xrp_address = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes an AccountantAccount message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.AccountantAccount} AccountantAccount
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        AccountantAccount.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies an AccountantAccount message.
-         * @function verify
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        AccountantAccount.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.name != null && message.hasOwnProperty("name"))
-                if (!$util.isString(message.name))
-                    return "name: string expected";
-            if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
-                if (!$util.isString(message.xrp_address))
-                    return "xrp_address: string expected";
-            return null;
-        };
-
-        /**
-         * Creates an AccountantAccount message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.AccountantAccount} AccountantAccount
-         */
-        AccountantAccount.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.AccountantAccount)
-                return object;
-            let message = new $root.main.AccountantAccount();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.name != null)
-                message.name = String(object.name);
-            if (object.xrp_address != null)
-                message.xrp_address = String(object.xrp_address);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from an AccountantAccount message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.AccountantAccount
-         * @static
-         * @param {main.AccountantAccount} message AccountantAccount
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        AccountantAccount.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.name = "";
-                object.xrp_address = "";
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.name != null && message.hasOwnProperty("name"))
-                object.name = message.name;
-            if (message.xrp_address != null && message.hasOwnProperty("xrp_address"))
-                object.xrp_address = message.xrp_address;
-            return object;
-        };
-
-        /**
-         * Converts this AccountantAccount to JSON.
-         * @function toJSON
-         * @memberof main.AccountantAccount
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        AccountantAccount.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return AccountantAccount;
     })();
 
     /**
@@ -1565,248 +1565,6 @@ export const main = $root.main = (() => {
         return AvailableBalance;
     })();
 
-    main.BalanceSnapshot = (function() {
-
-        /**
-         * Properties of a BalanceSnapshot.
-         * @memberof main
-         * @interface IBalanceSnapshot
-         * @property {string|null} [id] BalanceSnapshot id
-         * @property {string|null} [student_account_id] BalanceSnapshot student_account_id
-         * @property {string|null} [amount_uupx] BalanceSnapshot amount_uupx
-         * @property {string|null} [amount_uspx] BalanceSnapshot amount_uspx
-         */
-
-        /**
-         * Constructs a new BalanceSnapshot.
-         * @memberof main
-         * @classdesc Represents a BalanceSnapshot.
-         * @implements IBalanceSnapshot
-         * @constructor
-         * @param {main.IBalanceSnapshot=} [properties] Properties to set
-         */
-        function BalanceSnapshot(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * BalanceSnapshot id.
-         * @member {string} id
-         * @memberof main.BalanceSnapshot
-         * @instance
-         */
-        BalanceSnapshot.prototype.id = "";
-
-        /**
-         * BalanceSnapshot student_account_id.
-         * @member {string} student_account_id
-         * @memberof main.BalanceSnapshot
-         * @instance
-         */
-        BalanceSnapshot.prototype.student_account_id = "";
-
-        /**
-         * BalanceSnapshot amount_uupx.
-         * @member {string} amount_uupx
-         * @memberof main.BalanceSnapshot
-         * @instance
-         */
-        BalanceSnapshot.prototype.amount_uupx = "";
-
-        /**
-         * BalanceSnapshot amount_uspx.
-         * @member {string} amount_uspx
-         * @memberof main.BalanceSnapshot
-         * @instance
-         */
-        BalanceSnapshot.prototype.amount_uspx = "";
-
-        /**
-         * Encodes the specified BalanceSnapshot message. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
-         * @function encode
-         * @memberof main.BalanceSnapshot
-         * @static
-         * @param {main.IBalanceSnapshot} message BalanceSnapshot message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        BalanceSnapshot.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.student_account_id);
-            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
-            if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uspx);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified BalanceSnapshot message, length delimited. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.BalanceSnapshot
-         * @static
-         * @param {main.IBalanceSnapshot} message BalanceSnapshot message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        BalanceSnapshot.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes a BalanceSnapshot message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.BalanceSnapshot
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.BalanceSnapshot} BalanceSnapshot
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        BalanceSnapshot.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.BalanceSnapshot();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.student_account_id = reader.string();
-                    break;
-                case 3:
-                    message.amount_uupx = reader.string();
-                    break;
-                case 4:
-                    message.amount_uspx = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes a BalanceSnapshot message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.BalanceSnapshot
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.BalanceSnapshot} BalanceSnapshot
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        BalanceSnapshot.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies a BalanceSnapshot message.
-         * @function verify
-         * @memberof main.BalanceSnapshot
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        BalanceSnapshot.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
-                if (!$util.isString(message.student_account_id))
-                    return "student_account_id: string expected";
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                if (!$util.isString(message.amount_uupx))
-                    return "amount_uupx: string expected";
-            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                if (!$util.isString(message.amount_uspx))
-                    return "amount_uspx: string expected";
-            return null;
-        };
-
-        /**
-         * Creates a BalanceSnapshot message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.BalanceSnapshot
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.BalanceSnapshot} BalanceSnapshot
-         */
-        BalanceSnapshot.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.BalanceSnapshot)
-                return object;
-            let message = new $root.main.BalanceSnapshot();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.student_account_id != null)
-                message.student_account_id = String(object.student_account_id);
-            if (object.amount_uupx != null)
-                message.amount_uupx = String(object.amount_uupx);
-            if (object.amount_uspx != null)
-                message.amount_uspx = String(object.amount_uspx);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from a BalanceSnapshot message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.BalanceSnapshot
-         * @static
-         * @param {main.BalanceSnapshot} message BalanceSnapshot
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        BalanceSnapshot.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.student_account_id = "";
-                object.amount_uupx = "";
-                object.amount_uspx = "";
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
-                object.student_account_id = message.student_account_id;
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                object.amount_uupx = message.amount_uupx;
-            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                object.amount_uspx = message.amount_uspx;
-            return object;
-        };
-
-        /**
-         * Converts this BalanceSnapshot to JSON.
-         * @function toJSON
-         * @memberof main.BalanceSnapshot
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        BalanceSnapshot.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return BalanceSnapshot;
-    })();
-
     main.Balance = (function() {
 
         /**
@@ -2047,6 +1805,248 @@ export const main = $root.main = (() => {
         };
 
         return Balance;
+    })();
+
+    main.BalanceSnapshot = (function() {
+
+        /**
+         * Properties of a BalanceSnapshot.
+         * @memberof main
+         * @interface IBalanceSnapshot
+         * @property {string|null} [id] BalanceSnapshot id
+         * @property {string|null} [student_account_id] BalanceSnapshot student_account_id
+         * @property {string|null} [amount_uupx] BalanceSnapshot amount_uupx
+         * @property {string|null} [amount_uspx] BalanceSnapshot amount_uspx
+         */
+
+        /**
+         * Constructs a new BalanceSnapshot.
+         * @memberof main
+         * @classdesc Represents a BalanceSnapshot.
+         * @implements IBalanceSnapshot
+         * @constructor
+         * @param {main.IBalanceSnapshot=} [properties] Properties to set
+         */
+        function BalanceSnapshot(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * BalanceSnapshot id.
+         * @member {string} id
+         * @memberof main.BalanceSnapshot
+         * @instance
+         */
+        BalanceSnapshot.prototype.id = "";
+
+        /**
+         * BalanceSnapshot student_account_id.
+         * @member {string} student_account_id
+         * @memberof main.BalanceSnapshot
+         * @instance
+         */
+        BalanceSnapshot.prototype.student_account_id = "";
+
+        /**
+         * BalanceSnapshot amount_uupx.
+         * @member {string} amount_uupx
+         * @memberof main.BalanceSnapshot
+         * @instance
+         */
+        BalanceSnapshot.prototype.amount_uupx = "";
+
+        /**
+         * BalanceSnapshot amount_uspx.
+         * @member {string} amount_uspx
+         * @memberof main.BalanceSnapshot
+         * @instance
+         */
+        BalanceSnapshot.prototype.amount_uspx = "";
+
+        /**
+         * Encodes the specified BalanceSnapshot message. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
+         * @function encode
+         * @memberof main.BalanceSnapshot
+         * @static
+         * @param {main.IBalanceSnapshot} message BalanceSnapshot message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        BalanceSnapshot.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.student_account_id != null && Object.hasOwnProperty.call(message, "student_account_id"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.student_account_id);
+            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
+            if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uspx);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified BalanceSnapshot message, length delimited. Does not implicitly {@link main.BalanceSnapshot.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.BalanceSnapshot
+         * @static
+         * @param {main.IBalanceSnapshot} message BalanceSnapshot message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        BalanceSnapshot.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a BalanceSnapshot message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.BalanceSnapshot
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.BalanceSnapshot} BalanceSnapshot
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        BalanceSnapshot.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.BalanceSnapshot();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.student_account_id = reader.string();
+                    break;
+                case 3:
+                    message.amount_uupx = reader.string();
+                    break;
+                case 4:
+                    message.amount_uspx = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a BalanceSnapshot message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.BalanceSnapshot
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.BalanceSnapshot} BalanceSnapshot
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        BalanceSnapshot.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a BalanceSnapshot message.
+         * @function verify
+         * @memberof main.BalanceSnapshot
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        BalanceSnapshot.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                if (!$util.isString(message.student_account_id))
+                    return "student_account_id: string expected";
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                if (!$util.isString(message.amount_uupx))
+                    return "amount_uupx: string expected";
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                if (!$util.isString(message.amount_uspx))
+                    return "amount_uspx: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a BalanceSnapshot message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.BalanceSnapshot
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.BalanceSnapshot} BalanceSnapshot
+         */
+        BalanceSnapshot.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.BalanceSnapshot)
+                return object;
+            let message = new $root.main.BalanceSnapshot();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.student_account_id != null)
+                message.student_account_id = String(object.student_account_id);
+            if (object.amount_uupx != null)
+                message.amount_uupx = String(object.amount_uupx);
+            if (object.amount_uspx != null)
+                message.amount_uspx = String(object.amount_uspx);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a BalanceSnapshot message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.BalanceSnapshot
+         * @static
+         * @param {main.BalanceSnapshot} message BalanceSnapshot
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        BalanceSnapshot.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.student_account_id = "";
+                object.amount_uupx = "";
+                object.amount_uspx = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.student_account_id != null && message.hasOwnProperty("student_account_id"))
+                object.student_account_id = message.student_account_id;
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                object.amount_uupx = message.amount_uupx;
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                object.amount_uspx = message.amount_uspx;
+            return object;
+        };
+
+        /**
+         * Converts this BalanceSnapshot to JSON.
+         * @function toJSON
+         * @memberof main.BalanceSnapshot
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        BalanceSnapshot.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return BalanceSnapshot;
     })();
 
     main.ChatDelete = (function() {
@@ -6119,292 +6119,6 @@ export const main = $root.main = (() => {
         return NormalAskDelete;
     })();
 
-    main.NormalBidHistory = (function() {
-
-        /**
-         * Properties of a NormalBidHistory.
-         * @memberof main
-         * @interface INormalBidHistory
-         * @property {string|null} [id] NormalBidHistory id
-         * @property {string|null} [account_id] NormalBidHistory account_id
-         * @property {string|null} [price_ujpy] NormalBidHistory price_ujpy
-         * @property {string|null} [amount_uupx] NormalBidHistory amount_uupx
-         * @property {boolean|null} [is_accepted] NormalBidHistory is_accepted
-         * @property {string|null} [contract_price_ujpy] NormalBidHistory contract_price_ujpy
-         */
-
-        /**
-         * Constructs a new NormalBidHistory.
-         * @memberof main
-         * @classdesc Represents a NormalBidHistory.
-         * @implements INormalBidHistory
-         * @constructor
-         * @param {main.INormalBidHistory=} [properties] Properties to set
-         */
-        function NormalBidHistory(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * NormalBidHistory id.
-         * @member {string} id
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.id = "";
-
-        /**
-         * NormalBidHistory account_id.
-         * @member {string} account_id
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.account_id = "";
-
-        /**
-         * NormalBidHistory price_ujpy.
-         * @member {string} price_ujpy
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.price_ujpy = "";
-
-        /**
-         * NormalBidHistory amount_uupx.
-         * @member {string} amount_uupx
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.amount_uupx = "";
-
-        /**
-         * NormalBidHistory is_accepted.
-         * @member {boolean} is_accepted
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.is_accepted = false;
-
-        /**
-         * NormalBidHistory contract_price_ujpy.
-         * @member {string} contract_price_ujpy
-         * @memberof main.NormalBidHistory
-         * @instance
-         */
-        NormalBidHistory.prototype.contract_price_ujpy = "";
-
-        /**
-         * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-         * @function encode
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        NormalBidHistory.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.account_id != null && Object.hasOwnProperty.call(message, "account_id"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.account_id);
-            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.price_ujpy);
-            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uupx);
-            if (message.is_accepted != null && Object.hasOwnProperty.call(message, "is_accepted"))
-                writer.uint32(/* id 5, wireType 0 =*/40).bool(message.is_accepted);
-            if (message.contract_price_ujpy != null && Object.hasOwnProperty.call(message, "contract_price_ujpy"))
-                writer.uint32(/* id 6, wireType 2 =*/50).string(message.contract_price_ujpy);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        NormalBidHistory.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes a NormalBidHistory message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.NormalBidHistory} NormalBidHistory
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        NormalBidHistory.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalBidHistory();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.account_id = reader.string();
-                    break;
-                case 3:
-                    message.price_ujpy = reader.string();
-                    break;
-                case 4:
-                    message.amount_uupx = reader.string();
-                    break;
-                case 5:
-                    message.is_accepted = reader.bool();
-                    break;
-                case 6:
-                    message.contract_price_ujpy = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.NormalBidHistory} NormalBidHistory
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        NormalBidHistory.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies a NormalBidHistory message.
-         * @function verify
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        NormalBidHistory.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.account_id != null && message.hasOwnProperty("account_id"))
-                if (!$util.isString(message.account_id))
-                    return "account_id: string expected";
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                if (!$util.isString(message.price_ujpy))
-                    return "price_ujpy: string expected";
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                if (!$util.isString(message.amount_uupx))
-                    return "amount_uupx: string expected";
-            if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
-                if (typeof message.is_accepted !== "boolean")
-                    return "is_accepted: boolean expected";
-            if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
-                if (!$util.isString(message.contract_price_ujpy))
-                    return "contract_price_ujpy: string expected";
-            return null;
-        };
-
-        /**
-         * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.NormalBidHistory} NormalBidHistory
-         */
-        NormalBidHistory.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.NormalBidHistory)
-                return object;
-            let message = new $root.main.NormalBidHistory();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.account_id != null)
-                message.account_id = String(object.account_id);
-            if (object.price_ujpy != null)
-                message.price_ujpy = String(object.price_ujpy);
-            if (object.amount_uupx != null)
-                message.amount_uupx = String(object.amount_uupx);
-            if (object.is_accepted != null)
-                message.is_accepted = Boolean(object.is_accepted);
-            if (object.contract_price_ujpy != null)
-                message.contract_price_ujpy = String(object.contract_price_ujpy);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.NormalBidHistory
-         * @static
-         * @param {main.NormalBidHistory} message NormalBidHistory
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        NormalBidHistory.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.account_id = "";
-                object.price_ujpy = "";
-                object.amount_uupx = "";
-                object.is_accepted = false;
-                object.contract_price_ujpy = "";
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.account_id != null && message.hasOwnProperty("account_id"))
-                object.account_id = message.account_id;
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                object.price_ujpy = message.price_ujpy;
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                object.amount_uupx = message.amount_uupx;
-            if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
-                object.is_accepted = message.is_accepted;
-            if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
-                object.contract_price_ujpy = message.contract_price_ujpy;
-            return object;
-        };
-
-        /**
-         * Converts this NormalBidHistory to JSON.
-         * @function toJSON
-         * @memberof main.NormalBidHistory
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        NormalBidHistory.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return NormalBidHistory;
-    })();
-
     /**
      * NormalAskHistoryType enum.
      * @name main.NormalAskHistoryType
@@ -6747,270 +6461,6 @@ export const main = $root.main = (() => {
         return NormalAskHistory;
     })();
 
-    main.NormalAskSetting = (function() {
-
-        /**
-         * Properties of a NormalAskSetting.
-         * @memberof main
-         * @interface INormalAskSetting
-         * @property {string|null} [id] NormalAskSetting id
-         * @property {string|null} [price_ujpy] NormalAskSetting price_ujpy
-         * @property {string|null} [amount_uupx] NormalAskSetting amount_uupx
-         * @property {string|null} [ratio_percentage] NormalAskSetting ratio_percentage
-         * @property {boolean|null} [enable] NormalAskSetting enable
-         */
-
-        /**
-         * Constructs a new NormalAskSetting.
-         * @memberof main
-         * @classdesc Represents a NormalAskSetting.
-         * @implements INormalAskSetting
-         * @constructor
-         * @param {main.INormalAskSetting=} [properties] Properties to set
-         */
-        function NormalAskSetting(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * NormalAskSetting id.
-         * @member {string} id
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.id = "";
-
-        /**
-         * NormalAskSetting price_ujpy.
-         * @member {string} price_ujpy
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.price_ujpy = "";
-
-        /**
-         * NormalAskSetting amount_uupx.
-         * @member {string} amount_uupx
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.amount_uupx = "";
-
-        /**
-         * NormalAskSetting ratio_percentage.
-         * @member {string} ratio_percentage
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.ratio_percentage = "";
-
-        /**
-         * NormalAskSetting enable.
-         * @member {boolean} enable
-         * @memberof main.NormalAskSetting
-         * @instance
-         */
-        NormalAskSetting.prototype.enable = false;
-
-        /**
-         * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-         * @function encode
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        NormalAskSetting.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
-            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
-            if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
-                writer.uint32(/* id 4, wireType 2 =*/34).string(message.ratio_percentage);
-            if (message.enable != null && Object.hasOwnProperty.call(message, "enable"))
-                writer.uint32(/* id 5, wireType 0 =*/40).bool(message.enable);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        NormalAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes a NormalAskSetting message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.NormalAskSetting} NormalAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        NormalAskSetting.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalAskSetting();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.price_ujpy = reader.string();
-                    break;
-                case 3:
-                    message.amount_uupx = reader.string();
-                    break;
-                case 4:
-                    message.ratio_percentage = reader.string();
-                    break;
-                case 5:
-                    message.enable = reader.bool();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.NormalAskSetting} NormalAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        NormalAskSetting.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies a NormalAskSetting message.
-         * @function verify
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        NormalAskSetting.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                if (!$util.isString(message.price_ujpy))
-                    return "price_ujpy: string expected";
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                if (!$util.isString(message.amount_uupx))
-                    return "amount_uupx: string expected";
-            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
-                if (!$util.isString(message.ratio_percentage))
-                    return "ratio_percentage: string expected";
-            if (message.enable != null && message.hasOwnProperty("enable"))
-                if (typeof message.enable !== "boolean")
-                    return "enable: boolean expected";
-            return null;
-        };
-
-        /**
-         * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.NormalAskSetting} NormalAskSetting
-         */
-        NormalAskSetting.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.NormalAskSetting)
-                return object;
-            let message = new $root.main.NormalAskSetting();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.price_ujpy != null)
-                message.price_ujpy = String(object.price_ujpy);
-            if (object.amount_uupx != null)
-                message.amount_uupx = String(object.amount_uupx);
-            if (object.ratio_percentage != null)
-                message.ratio_percentage = String(object.ratio_percentage);
-            if (object.enable != null)
-                message.enable = Boolean(object.enable);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.NormalAskSetting
-         * @static
-         * @param {main.NormalAskSetting} message NormalAskSetting
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        NormalAskSetting.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.price_ujpy = "";
-                object.amount_uupx = "";
-                object.ratio_percentage = "";
-                object.enable = false;
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                object.price_ujpy = message.price_ujpy;
-            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
-                object.amount_uupx = message.amount_uupx;
-            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
-                object.ratio_percentage = message.ratio_percentage;
-            if (message.enable != null && message.hasOwnProperty("enable"))
-                object.enable = message.enable;
-            return object;
-        };
-
-        /**
-         * Converts this NormalAskSetting to JSON.
-         * @function toJSON
-         * @memberof main.NormalAskSetting
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        NormalAskSetting.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return NormalAskSetting;
-    })();
-
     /**
      * NormalAskType enum.
      * @name main.NormalAskType
@@ -7331,6 +6781,270 @@ export const main = $root.main = (() => {
         return NormalAsk;
     })();
 
+    main.NormalAskSetting = (function() {
+
+        /**
+         * Properties of a NormalAskSetting.
+         * @memberof main
+         * @interface INormalAskSetting
+         * @property {string|null} [id] NormalAskSetting id
+         * @property {string|null} [price_ujpy] NormalAskSetting price_ujpy
+         * @property {string|null} [amount_uupx] NormalAskSetting amount_uupx
+         * @property {string|null} [ratio_percentage] NormalAskSetting ratio_percentage
+         * @property {boolean|null} [enable] NormalAskSetting enable
+         */
+
+        /**
+         * Constructs a new NormalAskSetting.
+         * @memberof main
+         * @classdesc Represents a NormalAskSetting.
+         * @implements INormalAskSetting
+         * @constructor
+         * @param {main.INormalAskSetting=} [properties] Properties to set
+         */
+        function NormalAskSetting(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * NormalAskSetting id.
+         * @member {string} id
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.id = "";
+
+        /**
+         * NormalAskSetting price_ujpy.
+         * @member {string} price_ujpy
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.price_ujpy = "";
+
+        /**
+         * NormalAskSetting amount_uupx.
+         * @member {string} amount_uupx
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.amount_uupx = "";
+
+        /**
+         * NormalAskSetting ratio_percentage.
+         * @member {string} ratio_percentage
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.ratio_percentage = "";
+
+        /**
+         * NormalAskSetting enable.
+         * @member {boolean} enable
+         * @memberof main.NormalAskSetting
+         * @instance
+         */
+        NormalAskSetting.prototype.enable = false;
+
+        /**
+         * Encodes the specified NormalAskSetting message. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+         * @function encode
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NormalAskSetting.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uupx);
+            if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.ratio_percentage);
+            if (message.enable != null && Object.hasOwnProperty.call(message, "enable"))
+                writer.uint32(/* id 5, wireType 0 =*/40).bool(message.enable);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified NormalAskSetting message, length delimited. Does not implicitly {@link main.NormalAskSetting.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {main.INormalAskSetting} message NormalAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NormalAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a NormalAskSetting message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.NormalAskSetting} NormalAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NormalAskSetting.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalAskSetting();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.price_ujpy = reader.string();
+                    break;
+                case 3:
+                    message.amount_uupx = reader.string();
+                    break;
+                case 4:
+                    message.ratio_percentage = reader.string();
+                    break;
+                case 5:
+                    message.enable = reader.bool();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a NormalAskSetting message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.NormalAskSetting} NormalAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NormalAskSetting.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a NormalAskSetting message.
+         * @function verify
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        NormalAskSetting.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                if (!$util.isString(message.price_ujpy))
+                    return "price_ujpy: string expected";
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                if (!$util.isString(message.amount_uupx))
+                    return "amount_uupx: string expected";
+            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                if (!$util.isString(message.ratio_percentage))
+                    return "ratio_percentage: string expected";
+            if (message.enable != null && message.hasOwnProperty("enable"))
+                if (typeof message.enable !== "boolean")
+                    return "enable: boolean expected";
+            return null;
+        };
+
+        /**
+         * Creates a NormalAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.NormalAskSetting} NormalAskSetting
+         */
+        NormalAskSetting.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.NormalAskSetting)
+                return object;
+            let message = new $root.main.NormalAskSetting();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.price_ujpy != null)
+                message.price_ujpy = String(object.price_ujpy);
+            if (object.amount_uupx != null)
+                message.amount_uupx = String(object.amount_uupx);
+            if (object.ratio_percentage != null)
+                message.ratio_percentage = String(object.ratio_percentage);
+            if (object.enable != null)
+                message.enable = Boolean(object.enable);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a NormalAskSetting message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.NormalAskSetting
+         * @static
+         * @param {main.NormalAskSetting} message NormalAskSetting
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        NormalAskSetting.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.price_ujpy = "";
+                object.amount_uupx = "";
+                object.ratio_percentage = "";
+                object.enable = false;
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                object.price_ujpy = message.price_ujpy;
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                object.amount_uupx = message.amount_uupx;
+            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                object.ratio_percentage = message.ratio_percentage;
+            if (message.enable != null && message.hasOwnProperty("enable"))
+                object.enable = message.enable;
+            return object;
+        };
+
+        /**
+         * Converts this NormalAskSetting to JSON.
+         * @function toJSON
+         * @memberof main.NormalAskSetting
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        NormalAskSetting.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return NormalAskSetting;
+    })();
+
     main.NormalBidDelete = (function() {
 
         /**
@@ -7527,6 +7241,292 @@ export const main = $root.main = (() => {
         };
 
         return NormalBidDelete;
+    })();
+
+    main.NormalBidHistory = (function() {
+
+        /**
+         * Properties of a NormalBidHistory.
+         * @memberof main
+         * @interface INormalBidHistory
+         * @property {string|null} [id] NormalBidHistory id
+         * @property {string|null} [account_id] NormalBidHistory account_id
+         * @property {string|null} [price_ujpy] NormalBidHistory price_ujpy
+         * @property {string|null} [amount_uupx] NormalBidHistory amount_uupx
+         * @property {boolean|null} [is_accepted] NormalBidHistory is_accepted
+         * @property {string|null} [contract_price_ujpy] NormalBidHistory contract_price_ujpy
+         */
+
+        /**
+         * Constructs a new NormalBidHistory.
+         * @memberof main
+         * @classdesc Represents a NormalBidHistory.
+         * @implements INormalBidHistory
+         * @constructor
+         * @param {main.INormalBidHistory=} [properties] Properties to set
+         */
+        function NormalBidHistory(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * NormalBidHistory id.
+         * @member {string} id
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.id = "";
+
+        /**
+         * NormalBidHistory account_id.
+         * @member {string} account_id
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.account_id = "";
+
+        /**
+         * NormalBidHistory price_ujpy.
+         * @member {string} price_ujpy
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.price_ujpy = "";
+
+        /**
+         * NormalBidHistory amount_uupx.
+         * @member {string} amount_uupx
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.amount_uupx = "";
+
+        /**
+         * NormalBidHistory is_accepted.
+         * @member {boolean} is_accepted
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.is_accepted = false;
+
+        /**
+         * NormalBidHistory contract_price_ujpy.
+         * @member {string} contract_price_ujpy
+         * @memberof main.NormalBidHistory
+         * @instance
+         */
+        NormalBidHistory.prototype.contract_price_ujpy = "";
+
+        /**
+         * Encodes the specified NormalBidHistory message. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+         * @function encode
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NormalBidHistory.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.account_id != null && Object.hasOwnProperty.call(message, "account_id"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.account_id);
+            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.price_ujpy);
+            if (message.amount_uupx != null && Object.hasOwnProperty.call(message, "amount_uupx"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.amount_uupx);
+            if (message.is_accepted != null && Object.hasOwnProperty.call(message, "is_accepted"))
+                writer.uint32(/* id 5, wireType 0 =*/40).bool(message.is_accepted);
+            if (message.contract_price_ujpy != null && Object.hasOwnProperty.call(message, "contract_price_ujpy"))
+                writer.uint32(/* id 6, wireType 2 =*/50).string(message.contract_price_ujpy);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified NormalBidHistory message, length delimited. Does not implicitly {@link main.NormalBidHistory.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {main.INormalBidHistory} message NormalBidHistory message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        NormalBidHistory.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a NormalBidHistory message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.NormalBidHistory} NormalBidHistory
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NormalBidHistory.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.NormalBidHistory();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.account_id = reader.string();
+                    break;
+                case 3:
+                    message.price_ujpy = reader.string();
+                    break;
+                case 4:
+                    message.amount_uupx = reader.string();
+                    break;
+                case 5:
+                    message.is_accepted = reader.bool();
+                    break;
+                case 6:
+                    message.contract_price_ujpy = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a NormalBidHistory message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.NormalBidHistory} NormalBidHistory
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        NormalBidHistory.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a NormalBidHistory message.
+         * @function verify
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        NormalBidHistory.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.account_id != null && message.hasOwnProperty("account_id"))
+                if (!$util.isString(message.account_id))
+                    return "account_id: string expected";
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                if (!$util.isString(message.price_ujpy))
+                    return "price_ujpy: string expected";
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                if (!$util.isString(message.amount_uupx))
+                    return "amount_uupx: string expected";
+            if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
+                if (typeof message.is_accepted !== "boolean")
+                    return "is_accepted: boolean expected";
+            if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
+                if (!$util.isString(message.contract_price_ujpy))
+                    return "contract_price_ujpy: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a NormalBidHistory message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.NormalBidHistory} NormalBidHistory
+         */
+        NormalBidHistory.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.NormalBidHistory)
+                return object;
+            let message = new $root.main.NormalBidHistory();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.account_id != null)
+                message.account_id = String(object.account_id);
+            if (object.price_ujpy != null)
+                message.price_ujpy = String(object.price_ujpy);
+            if (object.amount_uupx != null)
+                message.amount_uupx = String(object.amount_uupx);
+            if (object.is_accepted != null)
+                message.is_accepted = Boolean(object.is_accepted);
+            if (object.contract_price_ujpy != null)
+                message.contract_price_ujpy = String(object.contract_price_ujpy);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a NormalBidHistory message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.NormalBidHistory
+         * @static
+         * @param {main.NormalBidHistory} message NormalBidHistory
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        NormalBidHistory.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.account_id = "";
+                object.price_ujpy = "";
+                object.amount_uupx = "";
+                object.is_accepted = false;
+                object.contract_price_ujpy = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.account_id != null && message.hasOwnProperty("account_id"))
+                object.account_id = message.account_id;
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                object.price_ujpy = message.price_ujpy;
+            if (message.amount_uupx != null && message.hasOwnProperty("amount_uupx"))
+                object.amount_uupx = message.amount_uupx;
+            if (message.is_accepted != null && message.hasOwnProperty("is_accepted"))
+                object.is_accepted = message.is_accepted;
+            if (message.contract_price_ujpy != null && message.hasOwnProperty("contract_price_ujpy"))
+                object.contract_price_ujpy = message.contract_price_ujpy;
+            return object;
+        };
+
+        /**
+         * Converts this NormalBidHistory to JSON.
+         * @function toJSON
+         * @memberof main.NormalBidHistory
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        NormalBidHistory.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return NormalBidHistory;
     })();
 
     main.NormalBid = (function() {
@@ -8297,6 +8297,226 @@ export const main = $root.main = (() => {
         };
 
         return PrimaryAsk;
+    })();
+
+    main.PrimaryAskSetting = (function() {
+
+        /**
+         * Properties of a PrimaryAskSetting.
+         * @memberof main
+         * @interface IPrimaryAskSetting
+         * @property {string|null} [id] PrimaryAskSetting id
+         * @property {string|null} [price_ujpy] PrimaryAskSetting price_ujpy
+         * @property {string|null} [ratio_percentage] PrimaryAskSetting ratio_percentage
+         */
+
+        /**
+         * Constructs a new PrimaryAskSetting.
+         * @memberof main
+         * @classdesc Represents a PrimaryAskSetting.
+         * @implements IPrimaryAskSetting
+         * @constructor
+         * @param {main.IPrimaryAskSetting=} [properties] Properties to set
+         */
+        function PrimaryAskSetting(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * PrimaryAskSetting id.
+         * @member {string} id
+         * @memberof main.PrimaryAskSetting
+         * @instance
+         */
+        PrimaryAskSetting.prototype.id = "";
+
+        /**
+         * PrimaryAskSetting price_ujpy.
+         * @member {string} price_ujpy
+         * @memberof main.PrimaryAskSetting
+         * @instance
+         */
+        PrimaryAskSetting.prototype.price_ujpy = "";
+
+        /**
+         * PrimaryAskSetting ratio_percentage.
+         * @member {string} ratio_percentage
+         * @memberof main.PrimaryAskSetting
+         * @instance
+         */
+        PrimaryAskSetting.prototype.ratio_percentage = "";
+
+        /**
+         * Encodes the specified PrimaryAskSetting message. Does not implicitly {@link main.PrimaryAskSetting.verify|verify} messages.
+         * @function encode
+         * @memberof main.PrimaryAskSetting
+         * @static
+         * @param {main.IPrimaryAskSetting} message PrimaryAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        PrimaryAskSetting.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+            if (message.ratio_percentage != null && Object.hasOwnProperty.call(message, "ratio_percentage"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.ratio_percentage);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified PrimaryAskSetting message, length delimited. Does not implicitly {@link main.PrimaryAskSetting.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.PrimaryAskSetting
+         * @static
+         * @param {main.IPrimaryAskSetting} message PrimaryAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        PrimaryAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a PrimaryAskSetting message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.PrimaryAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.PrimaryAskSetting} PrimaryAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        PrimaryAskSetting.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.PrimaryAskSetting();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.price_ujpy = reader.string();
+                    break;
+                case 3:
+                    message.ratio_percentage = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a PrimaryAskSetting message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.PrimaryAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.PrimaryAskSetting} PrimaryAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        PrimaryAskSetting.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a PrimaryAskSetting message.
+         * @function verify
+         * @memberof main.PrimaryAskSetting
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        PrimaryAskSetting.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                if (!$util.isString(message.price_ujpy))
+                    return "price_ujpy: string expected";
+            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                if (!$util.isString(message.ratio_percentage))
+                    return "ratio_percentage: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a PrimaryAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.PrimaryAskSetting
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.PrimaryAskSetting} PrimaryAskSetting
+         */
+        PrimaryAskSetting.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.PrimaryAskSetting)
+                return object;
+            let message = new $root.main.PrimaryAskSetting();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.price_ujpy != null)
+                message.price_ujpy = String(object.price_ujpy);
+            if (object.ratio_percentage != null)
+                message.ratio_percentage = String(object.ratio_percentage);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a PrimaryAskSetting message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.PrimaryAskSetting
+         * @static
+         * @param {main.PrimaryAskSetting} message PrimaryAskSetting
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        PrimaryAskSetting.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.price_ujpy = "";
+                object.ratio_percentage = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                object.price_ujpy = message.price_ujpy;
+            if (message.ratio_percentage != null && message.hasOwnProperty("ratio_percentage"))
+                object.ratio_percentage = message.ratio_percentage;
+            return object;
+        };
+
+        /**
+         * Converts this PrimaryAskSetting to JSON.
+         * @function toJSON
+         * @memberof main.PrimaryAskSetting
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        PrimaryAskSetting.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return PrimaryAskSetting;
     })();
 
     main.PrimaryBid = (function() {
@@ -9081,226 +9301,6 @@ export const main = $root.main = (() => {
         return RenewableAskHistory;
     })();
 
-    main.RenewableAskSetting = (function() {
-
-        /**
-         * Properties of a RenewableAskSetting.
-         * @memberof main
-         * @interface IRenewableAskSetting
-         * @property {string|null} [id] RenewableAskSetting id
-         * @property {string|null} [price_ujpy] RenewableAskSetting price_ujpy
-         * @property {string|null} [amount_uspx] RenewableAskSetting amount_uspx
-         */
-
-        /**
-         * Constructs a new RenewableAskSetting.
-         * @memberof main
-         * @classdesc Represents a RenewableAskSetting.
-         * @implements IRenewableAskSetting
-         * @constructor
-         * @param {main.IRenewableAskSetting=} [properties] Properties to set
-         */
-        function RenewableAskSetting(properties) {
-            if (properties)
-                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                    if (properties[keys[i]] != null)
-                        this[keys[i]] = properties[keys[i]];
-        }
-
-        /**
-         * RenewableAskSetting id.
-         * @member {string} id
-         * @memberof main.RenewableAskSetting
-         * @instance
-         */
-        RenewableAskSetting.prototype.id = "";
-
-        /**
-         * RenewableAskSetting price_ujpy.
-         * @member {string} price_ujpy
-         * @memberof main.RenewableAskSetting
-         * @instance
-         */
-        RenewableAskSetting.prototype.price_ujpy = "";
-
-        /**
-         * RenewableAskSetting amount_uspx.
-         * @member {string} amount_uspx
-         * @memberof main.RenewableAskSetting
-         * @instance
-         */
-        RenewableAskSetting.prototype.amount_uspx = "";
-
-        /**
-         * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-         * @function encode
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        RenewableAskSetting.encode = function encode(message, writer) {
-            if (!writer)
-                writer = $Writer.create();
-            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
-                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
-            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
-                writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
-            if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
-                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
-            return writer;
-        };
-
-        /**
-         * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
-         * @function encodeDelimited
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
-         * @param {$protobuf.Writer} [writer] Writer to encode to
-         * @returns {$protobuf.Writer} Writer
-         */
-        RenewableAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
-            return this.encode(message, writer).ldelim();
-        };
-
-        /**
-         * Decodes a RenewableAskSetting message from the specified reader or buffer.
-         * @function decode
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @param {number} [length] Message length if known beforehand
-         * @returns {main.RenewableAskSetting} RenewableAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        RenewableAskSetting.decode = function decode(reader, length) {
-            if (!(reader instanceof $Reader))
-                reader = $Reader.create(reader);
-            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.RenewableAskSetting();
-            while (reader.pos < end) {
-                let tag = reader.uint32();
-                switch (tag >>> 3) {
-                case 1:
-                    message.id = reader.string();
-                    break;
-                case 2:
-                    message.price_ujpy = reader.string();
-                    break;
-                case 3:
-                    message.amount_uspx = reader.string();
-                    break;
-                default:
-                    reader.skipType(tag & 7);
-                    break;
-                }
-            }
-            return message;
-        };
-
-        /**
-         * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
-         * @function decodeDelimited
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-         * @returns {main.RenewableAskSetting} RenewableAskSetting
-         * @throws {Error} If the payload is not a reader or valid buffer
-         * @throws {$protobuf.util.ProtocolError} If required fields are missing
-         */
-        RenewableAskSetting.decodeDelimited = function decodeDelimited(reader) {
-            if (!(reader instanceof $Reader))
-                reader = new $Reader(reader);
-            return this.decode(reader, reader.uint32());
-        };
-
-        /**
-         * Verifies a RenewableAskSetting message.
-         * @function verify
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {Object.<string,*>} message Plain object to verify
-         * @returns {string|null} `null` if valid, otherwise the reason why it is not
-         */
-        RenewableAskSetting.verify = function verify(message) {
-            if (typeof message !== "object" || message === null)
-                return "object expected";
-            if (message.id != null && message.hasOwnProperty("id"))
-                if (!$util.isString(message.id))
-                    return "id: string expected";
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                if (!$util.isString(message.price_ujpy))
-                    return "price_ujpy: string expected";
-            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                if (!$util.isString(message.amount_uspx))
-                    return "amount_uspx: string expected";
-            return null;
-        };
-
-        /**
-         * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
-         * @function fromObject
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {Object.<string,*>} object Plain object
-         * @returns {main.RenewableAskSetting} RenewableAskSetting
-         */
-        RenewableAskSetting.fromObject = function fromObject(object) {
-            if (object instanceof $root.main.RenewableAskSetting)
-                return object;
-            let message = new $root.main.RenewableAskSetting();
-            if (object.id != null)
-                message.id = String(object.id);
-            if (object.price_ujpy != null)
-                message.price_ujpy = String(object.price_ujpy);
-            if (object.amount_uspx != null)
-                message.amount_uspx = String(object.amount_uspx);
-            return message;
-        };
-
-        /**
-         * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
-         * @function toObject
-         * @memberof main.RenewableAskSetting
-         * @static
-         * @param {main.RenewableAskSetting} message RenewableAskSetting
-         * @param {$protobuf.IConversionOptions} [options] Conversion options
-         * @returns {Object.<string,*>} Plain object
-         */
-        RenewableAskSetting.toObject = function toObject(message, options) {
-            if (!options)
-                options = {};
-            let object = {};
-            if (options.defaults) {
-                object.id = "";
-                object.price_ujpy = "";
-                object.amount_uspx = "";
-            }
-            if (message.id != null && message.hasOwnProperty("id"))
-                object.id = message.id;
-            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
-                object.price_ujpy = message.price_ujpy;
-            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
-                object.amount_uspx = message.amount_uspx;
-            return object;
-        };
-
-        /**
-         * Converts this RenewableAskSetting to JSON.
-         * @function toJSON
-         * @memberof main.RenewableAskSetting
-         * @instance
-         * @returns {Object.<string,*>} JSON object
-         */
-        RenewableAskSetting.prototype.toJSON = function toJSON() {
-            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-        };
-
-        return RenewableAskSetting;
-    })();
-
     /**
      * RenewableAskType enum.
      * @name main.RenewableAskType
@@ -9619,6 +9619,226 @@ export const main = $root.main = (() => {
         };
 
         return RenewableAsk;
+    })();
+
+    main.RenewableAskSetting = (function() {
+
+        /**
+         * Properties of a RenewableAskSetting.
+         * @memberof main
+         * @interface IRenewableAskSetting
+         * @property {string|null} [id] RenewableAskSetting id
+         * @property {string|null} [price_ujpy] RenewableAskSetting price_ujpy
+         * @property {string|null} [amount_uspx] RenewableAskSetting amount_uspx
+         */
+
+        /**
+         * Constructs a new RenewableAskSetting.
+         * @memberof main
+         * @classdesc Represents a RenewableAskSetting.
+         * @implements IRenewableAskSetting
+         * @constructor
+         * @param {main.IRenewableAskSetting=} [properties] Properties to set
+         */
+        function RenewableAskSetting(properties) {
+            if (properties)
+                for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * RenewableAskSetting id.
+         * @member {string} id
+         * @memberof main.RenewableAskSetting
+         * @instance
+         */
+        RenewableAskSetting.prototype.id = "";
+
+        /**
+         * RenewableAskSetting price_ujpy.
+         * @member {string} price_ujpy
+         * @memberof main.RenewableAskSetting
+         * @instance
+         */
+        RenewableAskSetting.prototype.price_ujpy = "";
+
+        /**
+         * RenewableAskSetting amount_uspx.
+         * @member {string} amount_uspx
+         * @memberof main.RenewableAskSetting
+         * @instance
+         */
+        RenewableAskSetting.prototype.amount_uspx = "";
+
+        /**
+         * Encodes the specified RenewableAskSetting message. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+         * @function encode
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        RenewableAskSetting.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.id != null && Object.hasOwnProperty.call(message, "id"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.id);
+            if (message.price_ujpy != null && Object.hasOwnProperty.call(message, "price_ujpy"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.price_ujpy);
+            if (message.amount_uspx != null && Object.hasOwnProperty.call(message, "amount_uspx"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.amount_uspx);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified RenewableAskSetting message, length delimited. Does not implicitly {@link main.RenewableAskSetting.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {main.IRenewableAskSetting} message RenewableAskSetting message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        RenewableAskSetting.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a RenewableAskSetting message from the specified reader or buffer.
+         * @function decode
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {main.RenewableAskSetting} RenewableAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        RenewableAskSetting.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            let end = length === undefined ? reader.len : reader.pos + length, message = new $root.main.RenewableAskSetting();
+            while (reader.pos < end) {
+                let tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.id = reader.string();
+                    break;
+                case 2:
+                    message.price_ujpy = reader.string();
+                    break;
+                case 3:
+                    message.amount_uspx = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a RenewableAskSetting message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {main.RenewableAskSetting} RenewableAskSetting
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        RenewableAskSetting.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a RenewableAskSetting message.
+         * @function verify
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        RenewableAskSetting.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.id != null && message.hasOwnProperty("id"))
+                if (!$util.isString(message.id))
+                    return "id: string expected";
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                if (!$util.isString(message.price_ujpy))
+                    return "price_ujpy: string expected";
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                if (!$util.isString(message.amount_uspx))
+                    return "amount_uspx: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a RenewableAskSetting message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {main.RenewableAskSetting} RenewableAskSetting
+         */
+        RenewableAskSetting.fromObject = function fromObject(object) {
+            if (object instanceof $root.main.RenewableAskSetting)
+                return object;
+            let message = new $root.main.RenewableAskSetting();
+            if (object.id != null)
+                message.id = String(object.id);
+            if (object.price_ujpy != null)
+                message.price_ujpy = String(object.price_ujpy);
+            if (object.amount_uspx != null)
+                message.amount_uspx = String(object.amount_uspx);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a RenewableAskSetting message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof main.RenewableAskSetting
+         * @static
+         * @param {main.RenewableAskSetting} message RenewableAskSetting
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        RenewableAskSetting.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            let object = {};
+            if (options.defaults) {
+                object.id = "";
+                object.price_ujpy = "";
+                object.amount_uspx = "";
+            }
+            if (message.id != null && message.hasOwnProperty("id"))
+                object.id = message.id;
+            if (message.price_ujpy != null && message.hasOwnProperty("price_ujpy"))
+                object.price_ujpy = message.price_ujpy;
+            if (message.amount_uspx != null && message.hasOwnProperty("amount_uspx"))
+                object.amount_uspx = message.amount_uspx;
+            return object;
+        };
+
+        /**
+         * Converts this RenewableAskSetting to JSON.
+         * @function toJSON
+         * @memberof main.RenewableAskSetting
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        RenewableAskSetting.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return RenewableAskSetting;
     })();
 
     main.RenewableBidDelete = (function() {

--- a/functions/src/cost-settings/calc-monthly-payment.ts
+++ b/functions/src/cost-settings/calc-monthly-payment.ts
@@ -18,7 +18,7 @@ cost_setting.onCreateHandler.push(async (snapshot, context) => {
   const sale = parseInt(monthlySettlement[0].sale_utoken);
   const primaryAsks = await primary_ask.listLastMonth();
 
-  const primaryPrice = primaryAsks.length ? parseInt(primaryAsks[0].price_ujpy) : 27;
+  const primaryPrice = primaryAsks.length ? parseInt(primaryAsks[0].price_ujpy) : 21.5;
 
   // 0で割るのを避ける
   let discountRate: number;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -74,6 +74,7 @@ const files = {
   normal_bids: './normal-bids',
   normal_settlements: './normal-settlements',
   primary_asks: './primary-asks',
+  primary_ask_settings: './primary-ask-settings',
   primary_bids: './primary-bids',
   renewable_ask_deletes: './renewable-ask-deletes',
   renewable_ask_histories: './renewable-ask-histories',

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -14,6 +14,7 @@ import './normal-bid-deletes/delete-normal-bid';
 import './normal-settlements/create-balance';
 import './primary-asks/create-balance';
 import './renewable-ask-deletes/delete-renewable-ask';
+import './renewable-ask-settings/update-price';
 import './renewable-asks/update-available-balance';
 import './renewable-bid-deletes/delete-renewable-bid';
 import './renewable-settlements/create-balance';

--- a/functions/src/monthly-usages/create-primary-ask.ts
+++ b/functions/src/monthly-usages/create-primary-ask.ts
@@ -31,11 +31,11 @@ export const monthlyUsageOnCreate = async (snapshot: any, context: any) => {
     if (!uupxAmount) {
       console.log(student.room_id, 'have no usage data');
     }
-    primaryAsk = new PrimaryAsk({ account_id: studentID, price_ujpy: '27000000', amount_uupx: uupxAmount.toString() });
+    primaryAsk = new PrimaryAsk({ account_id: studentID, price_ujpy: '21500000', amount_uupx: uupxAmount.toString() });
   } else {
     // 一ヶ月以内に作成されたアカウントでない場合
     const issueAmount = data.amount_mwh;
-    primaryAsk = new PrimaryAsk({ account_id: studentID, price_ujpy: '27000000', amount_uupx: issueAmount });
+    primaryAsk = new PrimaryAsk({ account_id: studentID, price_ujpy: '21500000', amount_uupx: issueAmount });
   }
 
   await primary_ask.create(primaryAsk);

--- a/functions/src/primary-ask-settings/controller.ts
+++ b/functions/src/primary-ask-settings/controller.ts
@@ -1,0 +1,54 @@
+import { FirestoreCreateHandler, FirestoreDeleteHandler, FirestoreUpdateHandler } from '../triggers';
+
+// import { isTriggeredOnce } from '../triggers/module';
+// import { PrimaryAskSettingFirestore } from '@local/common';
+// import * as functions from 'firebase-functions';
+
+export const onCreateHandler: FirestoreCreateHandler[] = [];
+export const onUpdateHandler: FirestoreUpdateHandler[] = [];
+export const onDeleteHandler: FirestoreDeleteHandler[] = [];
+
+// export const onCreate = functions.firestore.document(PrimaryAskSettingFirestore.virtualPath).onCreate(async (snapshot, context) => {
+//   if (await isTriggeredOnce(context.eventId)) {
+//     return;
+//   }
+
+//   for (const handler of onCreateHandler) {
+//     try {
+//       await handler(snapshot, context);
+//     } catch (e) {
+//       console.error(`Error: in function ${handler.name}`);
+//       console.error(e);
+//     }
+//   }
+// });
+
+// export const onUpdate = functions.firestore.document(PrimaryAskSettingFirestore.virtualPath).onUpdate(async (snapshot, context) => {
+//   if (await isTriggeredOnce(context.eventId)) {
+//     return;
+//   }
+
+//   for (const handler of onUpdateHandler) {
+//     try {
+//       await handler(snapshot, context);
+//     } catch (e) {
+//       console.error(`Error: in function ${handler.name}`);
+//       console.error(e);
+//     }
+//   }
+// });
+
+// export const onDelete = functions.firestore.document(PrimaryAskSettingFirestore.virtualPath).onDelete(async (snapshot, context) => {
+//   if (await isTriggeredOnce(context.eventId)) {
+//     return;
+//   }
+
+//   for (const handler of onDeleteHandler) {
+//     try {
+//       await handler(snapshot, context);
+//     } catch (e) {
+//       console.error(`Error: in function ${handler.name}`);
+//       console.error(e);
+//     }
+//   }
+// });

--- a/functions/src/primary-ask-settings/index.ts
+++ b/functions/src/primary-ask-settings/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line camelcase
+export * as primary_ask_setting from './module';

--- a/functions/src/primary-ask-settings/module.ts
+++ b/functions/src/primary-ask-settings/module.ts
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+/* eslint-disable require-jsdoc */
+import { PrimaryAskSetting, PrimaryAskSettingFirestore } from '@local/common';
+import * as admin from 'firebase-admin';
+
+export * from './controller';
+
+export function collection() {
+  return admin
+    .firestore()
+    .collection(PrimaryAskSettingFirestore.collectionPath())
+    .withConverter(PrimaryAskSettingFirestore.converter as any);
+}
+
+export function collectionGroup() {
+  return admin
+    .firestore()
+    .collectionGroup(PrimaryAskSettingFirestore.collectionID)
+    .withConverter(PrimaryAskSettingFirestore.converter as any);
+}
+
+export function document(id?: string) {
+  const col = collection();
+  return id ? col.doc(id) : col.doc();
+}
+
+export async function get(id: string) {
+  return await document(id)
+    .get()
+    .then((snapshot) => snapshot.data() as PrimaryAskSetting | undefined);
+}
+
+export async function getLatest() {
+  return await collection()
+    .orderBy('created_at', 'desc')
+    .get()
+    .then((snapshot) => snapshot.docs.map((doc) => doc.data() as PrimaryAskSetting)[0]);
+}
+
+export async function list() {
+  return await collection()
+    .get()
+    .then((snapshot) => snapshot.docs.map((doc) => doc.data() as PrimaryAskSetting));
+}
+
+export async function create(data: PrimaryAskSetting) {
+  const doc = document(data.id);
+  data.id = doc.id;
+
+  const now = admin.firestore.Timestamp.now();
+  data.created_at = now;
+  data.updated_at = now;
+
+  await doc.set(data);
+}
+
+export async function update(data: Partial<PrimaryAskSetting> & { id: string }) {
+  const now = admin.firestore.Timestamp.now();
+  data.updated_at = now;
+
+  await document(data.id).update(data);
+}
+
+export async function delete_(id: string) {
+  await document(id).delete();
+}

--- a/functions/src/renewable-ask-settings/controller.ts
+++ b/functions/src/renewable-ask-settings/controller.ts
@@ -1,27 +1,26 @@
 import { FirestoreCreateHandler, FirestoreDeleteHandler, FirestoreUpdateHandler } from '../triggers';
-
-// import { isTriggeredOnce } from '../triggers/module';
-// import { RenewableAskSettingFirestore } from '@local/common';
-// import * as functions from 'firebase-functions';
+import { isTriggeredOnce } from '../triggers/module';
+import { RenewableAskSettingFirestore } from '@local/common';
+import * as functions from 'firebase-functions';
 
 export const onCreateHandler: FirestoreCreateHandler[] = [];
 export const onUpdateHandler: FirestoreUpdateHandler[] = [];
 export const onDeleteHandler: FirestoreDeleteHandler[] = [];
 
-// const f = functions.region('asia-northeast1');
-// export const onCreate = f.firestore.document(RenewableAskSettingFirestore.virtualPath).onCreate(async (snapshot, context) => {
-//   if (await isTriggeredOnce(context.eventId)) {
-//     return;
-//   }
+const f = functions.region('asia-northeast1').runWith({ timeoutSeconds: 540, memory: '2GB' });
+module.exports.onCreate = f.firestore.document(RenewableAskSettingFirestore.virtualPath).onCreate(async (snapshot, context) => {
+  if (await isTriggeredOnce(context.eventId)) {
+    return;
+  }
 
-//   for (const handler of onCreateHandler) {
-//     try {
-//       await handler(snapshot, context);
-//     } catch (e) {
-//       console.error(e);
-//     }
-//   }
-// });
+  for (const handler of onCreateHandler) {
+    try {
+      await handler(snapshot, context);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+});
 
 // export const onUpdate = f.firestore.document(RenewableAskSettingFirestore.virtualPath).onUpdate(async (snapshot, context) => {
 //   if (await isTriggeredOnce(context.eventId)) {

--- a/functions/src/renewable-ask-settings/module.ts
+++ b/functions/src/renewable-ask-settings/module.ts
@@ -46,6 +46,13 @@ export async function list() {
     .then((snapshot) => snapshot.docs.map((doc) => doc.data() as RenewableAskSetting));
 }
 
+export async function listDesc() {
+  return await collection()
+    .orderBy('created_at', 'desc')
+    .get()
+    .then((snapshot) => snapshot.docs.map((doc) => doc.data() as RenewableAskSetting));
+}
+
 export async function create(data: RenewableAskSetting) {
   const doc = document();
   data.id = doc.id;

--- a/functions/src/renewable-ask-settings/update-price.ts
+++ b/functions/src/renewable-ask-settings/update-price.ts
@@ -1,0 +1,13 @@
+/* eslint-disable camelcase */
+import { renewable_ask_setting } from '.';
+import { RenewableAskSetting } from '@local/common';
+
+renewable_ask_setting.onCreateHandler.push(async (snapshot, context) => {
+  const data = snapshot.data()! as RenewableAskSetting;
+  const settings = await renewable_ask_setting.listDesc();
+  if (settings.length > 1) {
+    const price = settings[1].price_ujpy;
+    await renewable_ask_setting.update({ id: data.id, price_ujpy: price });
+    console.log('New renewable-ask-setting created.');
+  }
+});

--- a/functions/src/schedules/operation-normal.ts
+++ b/functions/src/schedules/operation-normal.ts
@@ -21,12 +21,12 @@ module.exports.operationNormal = f.pubsub
     // 価格の決定
     const setting = await normal_ask_setting.getLatest();
     const now = new Date();
-    const price = !setting || now.getDate() == 1 ? 27000000 : parseInt(setting.price_ujpy);
+    const price = !setting || now.getDate() == 1 ? 21500000 : parseInt(setting.price_ujpy);
     const ratio = setting.ratio_percentage ? parseInt(setting.ratio_percentage) : 100;
     const enable = setting.enable ? setting.enable : false;
 
     await normal_ask_setting.create(
-      new NormalAskSetting({ price_ujpy: (price + 100000).toString(), ratio_percentage: ratio.toString(), enable: enable }),
+      new NormalAskSetting({ price_ujpy: price.toString(), ratio_percentage: ratio.toString(), enable: enable }),
     );
 
     const adminAccount = await admin_account.getByName('admin');

--- a/functions/src/schedules/operation-renewable.ts
+++ b/functions/src/schedules/operation-renewable.ts
@@ -18,7 +18,7 @@ module.exports.operationRenewable = f.pubsub
     const setting = await renewable_ask_setting.getLatest();
     const type = proto.main.RenewableAskType.PRIMARY;
     const adminAccount = await admin_account.getByName('admin');
-    const price = !setting.price_ujpy || now.getDate() == 1 ? '27500000' : setting.price_ujpy;
+    const price = !setting.price_ujpy || now.getDate() == 1 ? '22000000' : setting.price_ujpy;
 
     const dailyUsages = await daily_usage.listYesterday();
     const dailyUsageAmount = dailyUsages.reduce((previous, current) => previous + parseInt(current.amount_kwh_str), 0) * 1000000;
@@ -51,8 +51,8 @@ module.exports.operationRenewable = f.pubsub
 
     await renewable_ask_setting.create(
       new RenewableAskSetting({
-        price_ujpy: (parseInt(price) + 100000).toString(),
-        amount_uspx: !setting.amount_uspx ? amount : setting.amount_uspx,
+        price_ujpy: price,
+        amount_uspx: !setting.amount_uspx ? '25000000' : setting.amount_uspx,
       }),
     );
   });

--- a/functions/src/student-accounts/xrpl.ts
+++ b/functions/src/student-accounts/xrpl.ts
@@ -7,6 +7,7 @@ import { student_account } from '.';
 import { account_private } from '../account-privates';
 import { admin_account } from '../admin-accounts';
 import { daily_usage } from '../daily-usages';
+import { primary_ask_setting } from '../primary-ask-settings';
 import { primary_ask } from '../primary-asks';
 import { primaryAskOnCreate } from '../primary-asks/create-balance';
 import { AccountPrivate, PrimaryAsk, StudentAccount } from '@local/common';
@@ -99,7 +100,11 @@ student_account.onCreateHandler.push(async (snapshot, context) => {
   if (!uupxAmount) {
     console.log(student.room_id, 'have no usage data');
   }
-  const primaryAsk = new PrimaryAsk({ account_id: data.id, price_ujpy: '21500000', amount_uupx: uupxAmount.toString() });
+  const primaryAskSetting = await primary_ask_setting.getLatest();
+  const price = primaryAskSetting.price_ujpy ?? '21500000';
+  const ratio = parseInt(primaryAskSetting.ratio_percentage) / 100 ?? 1;
+
+  const primaryAsk = new PrimaryAsk({ account_id: data.id, price_ujpy: price, amount_uupx: (uupxAmount * ratio).toString() });
   await primary_ask.create(primaryAsk);
   await primaryAskOnCreate({ data: () => primaryAsk }, null);
 });

--- a/functions/src/student-accounts/xrpl.ts
+++ b/functions/src/student-accounts/xrpl.ts
@@ -99,7 +99,7 @@ student_account.onCreateHandler.push(async (snapshot, context) => {
   if (!uupxAmount) {
     console.log(student.room_id, 'have no usage data');
   }
-  const primaryAsk = new PrimaryAsk({ account_id: data.id, price_ujpy: '27000000', amount_uupx: uupxAmount.toString() });
+  const primaryAsk = new PrimaryAsk({ account_id: data.id, price_ujpy: '21500000', amount_uupx: uupxAmount.toString() });
   await primary_ask.create(primaryAsk);
   await primaryAskOnCreate({ data: () => primaryAsk }, null);
 });

--- a/projects/main/src/app/page/admin/tokens/tokens.component.html
+++ b/projects/main/src/app/page/admin/tokens/tokens.component.html
@@ -1,8 +1,10 @@
 <view-tokens
+  [primarySetting]="primarySetting$ | async"
   [normalSetting]="normalSetting$ | async"
   [renewableSetting]="renewableSetting$ | async"
   [costSetting]="costSetting$ | async"
   [renewableRewardSetting]="renewableRewardSetting$ | async"
+  (appSubmitPrimary)="onSubmitPrimary($event)"
   (appSubmitNormal)="onSubmitNormal($event)"
   (appSubmitRenewable)="onSubmitRenewable($event)"
   (appSubmitCost)="onSubmitCost($event)"

--- a/projects/main/src/app/page/admin/tokens/tokens.component.ts
+++ b/projects/main/src/app/page/admin/tokens/tokens.component.ts
@@ -1,13 +1,15 @@
 import {
   SetCostOnSubmitEvent,
   SetNormalOnSubmitEvent,
+  SetPrimaryOnSubmitEvent,
   SetRenewableOnSubmitEvent,
   SetRewardOnSubmitEvent,
 } from '../../../view/admin/tokens/tokens.component';
 import { Component, OnInit } from '@angular/core';
-import { CostSetting, NormalAskSetting, RenewableAskSetting, RenewableRewardSetting } from '@local/common';
+import { CostSetting, NormalAskSetting, PrimaryAskSetting, RenewableAskSetting, RenewableRewardSetting } from '@local/common';
 import { CostSettingApplicationService } from 'projects/shared/src/lib/services/cost-settings/cost-setting.application.service';
 import { NormalAskSettingApplicationService } from 'projects/shared/src/lib/services/normal-ask-settings/normal-ask-setting.application.service';
+import { PrimaryAskSettingApplicationService } from 'projects/shared/src/lib/services/primary-ask-settings/primary-ask-setting.application.service';
 import { RenewableAskSettingApplicationService } from 'projects/shared/src/lib/services/renewable-ask-settings/renewable-ask-setting.application.service';
 import { RenewableRewardSettingApplicationService } from 'projects/shared/src/lib/services/renewable-reward-settings/renewable-reward-setting.application.service';
 import { Observable } from 'rxjs';
@@ -18,17 +20,20 @@ import { Observable } from 'rxjs';
   styleUrls: ['./tokens.component.css'],
 })
 export class TokensComponent implements OnInit {
+  primarySetting$: Observable<PrimaryAskSetting> | undefined;
   normalSetting$: Observable<NormalAskSetting> | undefined;
   renewableSetting$: Observable<RenewableAskSetting> | undefined;
   costSetting$: Observable<CostSetting> | undefined;
   renewableRewardSetting$: Observable<RenewableRewardSetting>;
 
   constructor(
+    private readonly primaryAskSettingApp: PrimaryAskSettingApplicationService,
     private readonly normalAskSettingApp: NormalAskSettingApplicationService,
     private readonly renewableAskSettingApp: RenewableAskSettingApplicationService,
     private readonly costSettingApp: CostSettingApplicationService,
     private readonly renewableRewardSettingApp: RenewableRewardSettingApplicationService,
   ) {
+    this.primarySetting$ = this.primaryAskSettingApp.getLatest$();
     this.normalSetting$ = this.normalAskSettingApp.getLatest$();
     this.renewableSetting$ = this.renewableAskSettingApp.getLatest$();
     this.costSetting$ = this.costSettingApp.getLatest$();
@@ -36,6 +41,15 @@ export class TokensComponent implements OnInit {
   }
 
   ngOnInit(): void {}
+
+  async onSubmitPrimary($event: SetPrimaryOnSubmitEvent) {
+    await this.primaryAskSettingApp.create(
+      new NormalAskSetting({
+        price_ujpy: $event.ujpyPrice,
+        ratio_percentage: $event.uupxRatio,
+      }),
+    );
+  }
 
   async onSubmitNormal($event: SetNormalOnSubmitEvent) {
     await this.normalAskSettingApp.create(

--- a/projects/main/src/app/page/txs/buy/buy.component.ts
+++ b/projects/main/src/app/page/txs/buy/buy.component.ts
@@ -51,7 +51,7 @@ export class BuyComponent implements OnInit {
     private readonly singlePriceRenewableApp: SinglePriceRenewableSettlementApplicationService,
     private readonly ordersChartApp: ChartOrderService,
   ) {
-    this.price = 27;
+    this.price = 21.5;
     this.amount = 1;
     let firstDay = new Date();
     firstDay.setUTCDate(1);

--- a/projects/main/src/app/page/txs/sell/sell.component.ts
+++ b/projects/main/src/app/page/txs/sell/sell.component.ts
@@ -51,7 +51,7 @@ export class SellComponent implements OnInit {
     private readonly singlePriceRenewableApp: SinglePriceRenewableSettlementApplicationService,
     private readonly ordersChartApp: ChartOrderService,
   ) {
-    this.price = 27;
+    this.price = 21.5;
     this.amount = 1;
     let firstDay = new Date();
     firstDay.setUTCDate(1);

--- a/projects/main/src/app/view/admin/tokens/tokens.component.html
+++ b/projects/main/src/app/view/admin/tokens/tokens.component.html
@@ -1,15 +1,71 @@
 <div class="w-full lg:mx-auto lg:w-1/3 lg:mt-10">
   <h2>Token Issuance Setting</h2>
   <mat-card class="mb-10">
-    <mat-card-title>Next Issue UPX Price</mat-card-title>
+    <mat-card-title>UPX Setting (Next Month Issue)</mat-card-title>
     <mat-card-content>
-      <p>If the amount is not specified, the system will automatically supply the missing tokens.</p>
-      <p>The amount setting will only be applied to the next issue, and the price will automatically increase by 0.1 JPY daily.</p>
+      <p>Change the price of UPX issued on the first of the next month.</p>
+      <p>By changing the Ratio, specify what percentage of the previous month's usage will be initially issued.</p>
     </mat-card-content>
-    <ng-container *ngIf="normalSetting === null; then loading; else loadedNormal"></ng-container>
+    <ng-container *ngIf="primarySetting === null; then loading; else loadedPrimary"></ng-container>
     <ng-template #loading>
       <mat-progress-spinner [diameter]="60" [mode]="'indeterminate'"></mat-progress-spinner>
     </ng-template>
+    <ng-template #loadedPrimary>
+      <mat-list>
+        <mat-list-item class="flex flex-wrap">
+          <span class="break-all">UPX Price:</span>
+          <span class="flex-auto break-all"></span>
+          <span class="break-all">{{ primarySetting?.price_ujpy | microString }} JPY</span>
+        </mat-list-item>
+        <mat-divider [inset]="true"></mat-divider>
+        <mat-list-item class="flex flex-wrap">
+          <span class="break-all">Ratio:</span>
+          <span class="flex-auto break-all"></span>
+          <ng-container *ngIf="!primarySetting?.ratio_percentage; then emptyPrimary; else existPrimary"></ng-container>
+          <ng-template #emptyPrimary><span class="break-all">100 %</span></ng-template>
+          <ng-template #existPrimary>
+            <span class="break-all">{{ primarySetting?.ratio_percentage }} %</span>
+          </ng-template>
+        </mat-list-item>
+      </mat-list>
+    </ng-template>
+  </mat-card>
+
+  <form (submit)="onSubmitPrimary(pricePrimaryRef.value, ratioPrimaryRef.value)">
+    <mat-card class="mb-10">
+      <mat-card-title>Change UPX Setting (Next Month Issue)</mat-card-title>
+      <mat-list>
+        <mat-list-item style="height: auto" class="flex flex-wrap">
+          <span class="break-all">Price:</span>
+          <span class="flex-auto break-all"></span>
+          <mat-form-field class="break-all">
+            <mat-label>Input Number</mat-label>
+            <input #pricePrimaryRef matInput type="number" name="price" required />
+          </mat-form-field>
+        </mat-list-item>
+        <mat-divider [inset]="true"></mat-divider>
+        <mat-list-item style="height: auto" class="flex flex-wrap">
+          <span class="break-all">Amount Ratio:</span>
+          <span class="flex-auto break-all"></span>
+          <mat-form-field class="break-all">
+            <mat-label>Input Int Percentage</mat-label>
+            <input #ratioPrimaryRef matInput type="number" name="ratio" />
+          </mat-form-field>
+        </mat-list-item>
+      </mat-list>
+      <div class="text-center mt-5">
+        <button mat-flat-button color="accent">Submit</button>
+      </div>
+    </mat-card>
+  </form>
+
+  <mat-card class="mb-10">
+    <mat-card-title>UPX Setting (Market Operation)</mat-card-title>
+    <mat-card-content>
+      <p>Change the price of UPX issued in daily open market operations.</p>
+      <p>Ratio toggles the magnitude of market operations, Enable toggles enable/disable.</p>
+    </mat-card-content>
+    <ng-container *ngIf="normalSetting === null; then loading; else loadedNormal"></ng-container>
     <ng-template #loadedNormal>
       <mat-list>
         <mat-list-item class="flex flex-wrap">
@@ -19,7 +75,7 @@
         </mat-list-item>
         <mat-divider [inset]="true"></mat-divider>
         <mat-list-item class="flex flex-wrap">
-          <span class="break-all">UPX amount:</span>
+          <span class="break-all">Amount Ratio:</span>
           <span class="flex-auto break-all"></span>
           <ng-container *ngIf="!normalSetting?.ratio_percentage; then emptyNormal; else existNormal"></ng-container>
           <ng-template #emptyNormal><span class="break-all">100 %</span></ng-template>
@@ -72,8 +128,8 @@
   <mat-card class="mt-20 mb-10">
     <mat-card-title>Next Issue SPX Price</mat-card-title>
     <mat-card-content>
-      <p>Both the amount and the price need to be entered.</p>
-      <p>The same amount will be issued until the next change, and the price will automatically increase by 0.1 JPY daily.</p>
+      <p>Changes the amount and price of SPX for the next system sell order.</p>
+      <p>The amount is changed daily around 10:00 a.m. by the energy server's data.</p>
     </mat-card-content>
     <ng-container *ngIf="renewableSetting === null; then loading; else loadedRenewable"></ng-container>
     <ng-template #loadedRenewable>

--- a/projects/main/src/app/view/admin/tokens/tokens.component.ts
+++ b/projects/main/src/app/view/admin/tokens/tokens.component.ts
@@ -1,5 +1,10 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { CostSetting, NormalAskSetting, RenewableAskSetting, RenewableRewardSetting } from '@local/common';
+import { CostSetting, NormalAskSetting, PrimaryAskSetting, RenewableAskSetting, RenewableRewardSetting } from '@local/common';
+
+export type SetPrimaryOnSubmitEvent = {
+  ujpyPrice: string;
+  uupxRatio: string;
+};
 
 export type SetNormalOnSubmitEvent = {
   ujpyPrice: string;
@@ -30,6 +35,8 @@ export type SetRewardOnSubmitEvent = {
 })
 export class TokensComponent implements OnInit {
   @Input()
+  primarySetting?: PrimaryAskSetting | null;
+  @Input()
   normalSetting?: NormalAskSetting | null;
   @Input()
   renewableSetting?: RenewableAskSetting | null;
@@ -37,6 +44,8 @@ export class TokensComponent implements OnInit {
   costSetting?: CostSetting | null;
   @Input()
   renewableRewardSetting?: RenewableRewardSetting | null;
+  @Output()
+  appSubmitPrimary: EventEmitter<SetPrimaryOnSubmitEvent>;
   @Output()
   appSubmitNormal: EventEmitter<SetNormalOnSubmitEvent>;
   @Output()
@@ -49,6 +58,7 @@ export class TokensComponent implements OnInit {
   checked: boolean = false;
 
   constructor() {
+    this.appSubmitPrimary = new EventEmitter();
     this.appSubmitNormal = new EventEmitter();
     this.appSubmitRenewable = new EventEmitter();
     this.appSubmitCost = new EventEmitter();
@@ -56,6 +66,16 @@ export class TokensComponent implements OnInit {
   }
 
   ngOnInit(): void {}
+
+  onSubmitPrimary(price: string, ratio: string) {
+    if (!price) {
+      alert('価格を設定してください');
+      return;
+    }
+    const ujpyPrice = Math.floor(Number(price) * 1000000).toString();
+    const uupxRatio = Math.floor(Number(ratio)).toString();
+    this.appSubmitPrimary.emit({ ujpyPrice, uupxRatio });
+  }
 
   onSubmitNormal(price: string, ratio: string) {
     if (!price) {

--- a/projects/main/src/app/view/dashboard/dashboard.component.html
+++ b/projects/main/src/app/view/dashboard/dashboard.component.html
@@ -67,8 +67,14 @@
 
           <div>
             <mat-card-content style="font-size: large; margin-top: 15px">Total</mat-card-content>
-            <canvas baseChart height="150" width="150" [data]="totalBalanceData!" [labels]="doughnutChartLabels"
-            [chartType]="doughnutChartType" [colors]="doughnutColors"
+            <canvas
+              baseChart
+              height="150"
+              width="150"
+              [data]="totalBalanceData!"
+              [labels]="doughnutChartLabels"
+              [chartType]="doughnutChartType"
+              [colors]="doughnutColors"
             >
             </canvas>
           </div>
@@ -229,6 +235,8 @@
           In addition to these, you have to pay fuel regulatory costs and renewable energy surcharge. So, the average price of electricity
           for end users is approximately <b>&yen;27/kWh</b>.
         </p>
+        <p style="color: #ff0000">The UPX base price has been changed to <b>&yen;21.5/kWh</b>.</p>
+        <p style="color: #ff0000">The SPX base price has been changed to <b>&yen;22.0/kWh</b> since Sep. Please note.</p>
       </mat-card-content>
     </mat-card>
   </div>

--- a/projects/main/src/app/view/dashboard/reference/reference.component.html
+++ b/projects/main/src/app/view/dashboard/reference/reference.component.html
@@ -37,5 +37,7 @@
       In addition to these, you have to pay fuel regulatory costs and renewable energy surcharge. So, the average price of electricity for
       end users is approximately <b>&yen;27/kWh</b>.
     </p>
+    <p style="color: #ff0000">The UPX base price has been changed to <b>&yen;21.5/kWh</b>.</p>
+    <p style="color: #ff0000">The SPX base price has been changed to <b>&yen;22.0/kWh</b> since Sep. Please note.</p>
   </mat-card-content>
 </mat-card>

--- a/projects/main/src/app/view/txs/buy/buy.component.html
+++ b/projects/main/src/app/view/txs/buy/buy.component.html
@@ -194,7 +194,8 @@
         </mat-card-content>
       </details>
       <mat-card-content class="mt-5">
-        <p>The average price of electricity for end users is approximately <b>&yen;27/kWh</b>.</p>
+        <p style="color: #ff0000">The base price has been changed to <b>&yen;21.5/kWh</b>.</p>
+        <p style="color: #ff0000">The SPX base price has been changed to <b>&yen;22.0/kWh</b> since Sep. Please note.</p>
         <p>You cannot order between 9:00-11:00 (JST).</p>
       </mat-card-content>
       <mat-list>

--- a/projects/main/src/app/view/txs/sell/sell.component.html
+++ b/projects/main/src/app/view/txs/sell/sell.component.html
@@ -194,7 +194,8 @@
         </mat-card-content>
       </details>
       <mat-card-content class="mt-5">
-        <p>The average price of electricity for end users is approximately <b>&yen;27/kWh</b>.</p>
+        <p style="color: #ff0000">The UPX base price has been changed to <b>&yen;21.5/kWh</b>.</p>
+        <p style="color: #ff0000">The SPX base price has been changed to <b>&yen;22.0/kWh</b> since Sep. Please note.</p>
         <p>You cannot order between 9:00-11:00 (JST).</p>
       </mat-card-content>
       <mat-list>

--- a/projects/shared/src/lib/services/charts/chart-contracts/chart-contract.service.ts
+++ b/projects/shared/src/lib/services/charts/chart-contracts/chart-contract.service.ts
@@ -12,13 +12,20 @@ export const contractChartLegend = true;
 export class ChartContractService {
   constructor() {}
   createContractChartDataSets(settlements: SinglePriceNormalSettlement[] | SinglePriceRenewableSettlement[]) {
+    if (!settlements.length) {
+      console.log('No settlement data.');
+      return [];
+    }
     const prices = this.getPrices(settlements);
     const amounts = this.getAmounts(settlements);
     if (prices.length != amounts.length) {
-      console.log('It must be same length ');
+      console.log('It must be same length.');
       return [];
     }
-    const referencePrices = Array(prices.length).fill(21.5 as number);
+    const referencePrices =
+      settlements[0] instanceof SinglePriceNormalSettlement
+        ? Array(prices.length).fill(21.5 as number)
+        : Array(prices.length).fill(22.0 as number);
     const dataSets = [
       {
         data: referencePrices,

--- a/projects/shared/src/lib/services/charts/chart-contracts/chart-contract.service.ts
+++ b/projects/shared/src/lib/services/charts/chart-contracts/chart-contract.service.ts
@@ -18,7 +18,7 @@ export class ChartContractService {
       console.log('It must be same length ');
       return [];
     }
-    const referencePrices = Array(prices.length).fill(27 as number);
+    const referencePrices = Array(prices.length).fill(21.5 as number);
     const dataSets = [
       {
         data: referencePrices,

--- a/projects/shared/src/lib/services/primary-ask-settings/primary-ask-setting.application.service.ts
+++ b/projects/shared/src/lib/services/primary-ask-settings/primary-ask-setting.application.service.ts
@@ -1,0 +1,71 @@
+import { PrimaryAskSettingService } from './primary-ask-setting.service';
+import { Injectable } from '@angular/core';
+import { Timestamp } from '@angular/fire/firestore';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { PrimaryAskSetting } from '@local/common';
+import { LoadingDialogService } from 'ng-loading-dialog';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PrimaryAskSettingApplicationService {
+  constructor(
+    private readonly primaryAskSetting: PrimaryAskSettingService,
+    private readonly loadingDialog: LoadingDialogService,
+    private readonly snackBar: MatSnackBar,
+    private readonly router: Router,
+  ) {}
+
+  async create(data: PrimaryAskSetting) {
+    const dialogRef = this.loadingDialog.open('Sending New Setting');
+    try {
+      this.primaryAskSetting.create(data);
+    } catch {
+      this.snackBar.open('Error has occurred', undefined, {
+        duration: 6000,
+      });
+      return;
+    } finally {
+      dialogRef.close();
+    }
+
+    this.snackBar.open('Successfully Update Setting', undefined, {
+      duration: 6000,
+    });
+
+    await this.router.navigate(['admin/tokens']);
+  }
+
+  get$(id: string) {
+    return this.primaryAskSetting.get$(id);
+  }
+
+  getLatest$() {
+    return this.primaryAskSetting.list$().pipe(
+      map(
+        (settings) =>
+          settings.sort(function (first, second) {
+            if (!first.created_at) {
+              return 1;
+            } else if (!second.created_at) {
+              return -1;
+            } else {
+              if ((first.created_at as Timestamp).toDate() > (second.created_at as Timestamp).toDate()) {
+                return -1;
+              } else if ((first.created_at as Timestamp).toDate() < (second.created_at as Timestamp).toDate()) {
+                return 1;
+              } else {
+                return 0;
+              }
+            }
+          })[0],
+      ),
+    );
+  }
+
+  list$() {
+    return this.primaryAskSetting.list$();
+  }
+}

--- a/projects/shared/src/lib/services/primary-ask-settings/primary-ask-setting.infrastructure.service.ts
+++ b/projects/shared/src/lib/services/primary-ask-settings/primary-ask-setting.infrastructure.service.ts
@@ -1,0 +1,73 @@
+import { autoID } from '../auto-id';
+import { Injectable } from '@angular/core';
+import { Firestore, collection, collectionGroup, query, QueryConstraint, doc, getDoc, docData, getDocs, collectionData, setDoc, serverTimestamp } from '@angular/fire/firestore';
+import { IPrimaryAskSettingInfrastructureService } from './primary-ask-setting.service';
+import { PrimaryAskSetting } from '@local/common';
+import { PrimaryAskSettingFirestore } from '@local/common';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PrimaryAskSettingInfrastructureService
+  implements IPrimaryAskSettingInfrastructureService {
+
+  constructor(private readonly firestore: Firestore) {}
+
+  collection(...queryConstraints: QueryConstraint[]) {
+    const ref = collection(this.firestore, PrimaryAskSettingFirestore.collectionPath());
+
+    return (queryConstraints.length > 0
+      ? query(ref, ...queryConstraints) : ref).withConverter(PrimaryAskSettingFirestore.converter);
+  }
+
+  collectionGroup(...queryConstraints: QueryConstraint[]) {
+    const ref = collectionGroup(this.firestore, PrimaryAskSettingFirestore.collectionID);
+
+    return (queryConstraints.length > 0
+      ? query(ref, ...queryConstraints) : ref).withConverter(PrimaryAskSettingFirestore.converter);
+  }
+
+  document(id?: string) {
+    const ref = collection(this.firestore, PrimaryAskSettingFirestore.collectionPath());
+
+    return (id ? doc(this.firestore, ref.path, id) : doc(this.firestore, ref.path, autoID())).withConverter(PrimaryAskSettingFirestore.converter);
+  }
+
+  get(id: string) {
+    return getDoc(this.document(id))
+      .then(snapshot => snapshot.data());
+  }
+
+  get$(id: string) {
+    return docData(this.document(id));
+  }
+
+  list() {
+    return getDocs(this.collection())
+      .then(snapshots => snapshots.docs.map(doc => doc.data()))
+  }
+
+  list$() {
+    return collectionData(this.collection());
+  }
+
+  listGroup() {
+    return getDocs(this.collectionGroup())
+      .then(snapshots => snapshots.docs.map(doc => doc.data()))
+  }
+
+  listGroup$() {
+    return collectionData(this.collectionGroup());
+  }
+
+  create(data: PrimaryAskSetting) {
+    const doc = this.document(data.id);
+    data.id = doc.id;
+
+    const now = serverTimestamp();
+    data.created_at = now;
+    data.updated_at = now;
+
+    return setDoc(doc, data);
+  }
+}

--- a/projects/shared/src/lib/services/primary-ask-settings/primary-ask-setting.service.ts
+++ b/projects/shared/src/lib/services/primary-ask-settings/primary-ask-setting.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { PrimaryAskSettingInfrastructureService } from './primary-ask-setting.infrastructure.service';
+import { PrimaryAskSetting } from '@local/common';
+
+export interface IPrimaryAskSettingInfrastructureService {
+  get(id: string): Promise<PrimaryAskSetting | undefined>;
+  get$(id: string): Observable<PrimaryAskSetting | undefined>;
+  list(): Promise<PrimaryAskSetting[]>;
+  list$(): Observable<PrimaryAskSetting[]>;
+  listGroup(): Promise<PrimaryAskSetting[]>;
+  listGroup$(): Observable<PrimaryAskSetting[]>;
+  create(data: PrimaryAskSetting): Promise<void>;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PrimaryAskSettingService {
+  private iPrimaryAskSettingInfrastructure: IPrimaryAskSettingInfrastructureService;
+
+  constructor(readonly primaryAskSettingInfrastructure: PrimaryAskSettingInfrastructureService) {
+    this.iPrimaryAskSettingInfrastructure = primaryAskSettingInfrastructure;
+  }
+
+  get(id: string) {
+    return this.iPrimaryAskSettingInfrastructure.get(id);
+  }
+
+  get$(id: string) {
+    return this.iPrimaryAskSettingInfrastructure.get$(id);
+  }
+
+  list() {
+    return this.iPrimaryAskSettingInfrastructure.list();
+  }
+  
+  list$() {
+    return this.iPrimaryAskSettingInfrastructure.list$();
+  }
+  
+  listGroup() {
+    return this.iPrimaryAskSettingInfrastructure.listGroup();
+  }
+  
+  listGroup$() {
+    return this.iPrimaryAskSettingInfrastructure.listGroup$();
+  }
+
+  create(data: PrimaryAskSetting) {
+    return this.iPrimaryAskSettingInfrastructure.create(data);
+  }
+}


### PR DESCRIPTION
## 変更点
### バックエンド
- PrimaryAskで発行されるUPXの価格を可変にするためのデータベース変更
- Adminからのトークン注文価格が0.1JPYずつ上がる機能を廃止

### フロントエンド
- UPXの価格等を変更する管理者用フロントエンドへの機能追加
  - PrimaryAskの価格変更機能
  - PrimaryAskが前月の何割を対象としたトークン発行を行うかを変更する機能
- UPXとSPXの基準価格が変更された旨を赤字で注文ページ及びDashboardに表示
- 過去の成約履歴の基準価格線を変更

