### PR TITLE
Admin dashboardの修正

### DIFF
--- a/projects/main/src/app/view/admin/tokens/tokens.component.html
+++ b/projects/main/src/app/view/admin/tokens/tokens.component.html
@@ -95,7 +95,7 @@
 
   <form (submit)="onSubmitNormal(priceNormalRef.value, ratioNormalRef.value)">
     <mat-card class="mb-10">
-      <mat-card-title>Change UPX Setting</mat-card-title>
+      <mat-card-title>Change UPX Setting (Market Operation)</mat-card-title>
       <mat-list>
         <mat-list-item style="height: auto" class="flex flex-wrap">
           <span class="break-all">Price:</span>

--- a/projects/shared/src/lib/services/charts/chart-monthly-usages/chart-monthly-usage.service.ts
+++ b/projects/shared/src/lib/services/charts/chart-monthly-usages/chart-monthly-usage.service.ts
@@ -76,20 +76,25 @@ export class ChartMonthlyUsageService {
       const nextMonth = new Date(now.getFullYear(), i + 1, 1);
       const thisMonthLastYear = new Date(now.getFullYear() - 1, i, 1);
       const nextMonthLastYear = new Date(now.getFullYear() - 1, i + 1, 1);
-      const usage = usages.reduce(
-        (sum, element) =>
-          thisMonth < (element.created_at as Timestamp).toDate() && (element.created_at as Timestamp).toDate() < nextMonth
-            ? sum + parseInt(element.amount_kwh_str)
-            : sum,
-        0,
-      );
-      const usageLastYear = usages.reduce(
-        (sum, element) =>
-          thisMonthLastYear < (element.created_at as Timestamp).toDate() && (element.created_at as Timestamp).toDate() < nextMonthLastYear
-            ? sum + parseInt(element.amount_kwh_str)
-            : sum,
-        0,
-      );
+      const usage = usages
+        .filter((usage) => usage.created_at)
+        .reduce(
+          (sum, element) =>
+            thisMonth < (element.created_at as Timestamp).toDate() && (element.created_at as Timestamp).toDate() < nextMonth
+              ? sum + parseInt(element.amount_kwh_str)
+              : sum,
+          0,
+        );
+      console.log(usages.filter((usage) => !usage.created_at));
+      const usageLastYear = usages
+        .filter((usage) => usage.created_at)
+        .reduce(
+          (sum, element) =>
+            thisMonthLastYear < (element.created_at as Timestamp).toDate() && (element.created_at as Timestamp).toDate() < nextMonthLastYear
+              ? sum + parseInt(element.amount_kwh_str)
+              : sum,
+          0,
+        );
       totalUsageThisYear.push(usage);
       totalUsageLastYear.push(usageLastYear);
     }

--- a/projects/shared/src/lib/services/csvs/csv-daily-usages/csv-daily-usages.service.ts
+++ b/projects/shared/src/lib/services/csvs/csv-daily-usages/csv-daily-usages.service.ts
@@ -2,6 +2,7 @@ import { DailyUsageApplicationService } from '../../daily-usages/daily-usage.app
 import { DailyPaymentApplicationService } from '../../student-accounts/daily-payments/daily-payment.application.service';
 import { StudentAccountApplicationService } from '../../student-accounts/student-account.application.service';
 import { CSVCommonService } from '../csv-common.service';
+import { CsvOrderHistoriesService } from '../csv-order-histories/csv-order-histories.service';
 import { Injectable } from '@angular/core';
 import { Timestamp } from '@angular/fire/firestore';
 import { DailyPayment } from '@local/common';
@@ -16,13 +17,16 @@ export class CsvDailyUsagesService {
     private readonly studentApp: StudentAccountApplicationService,
     private readonly dailyUsageApp: DailyUsageApplicationService,
     private readonly dailyPaymentApp: DailyPaymentApplicationService,
+    private readonly csvOrderHistory: CsvOrderHistoriesService,
   ) {}
 
   async downloadDailyUsages(range: DateRange) {
+    const endDate = new Date(range.end);
+    endDate.setDate(endDate.getDate() + 1);
     const usages = await this.dailyUsageApp.list();
     const filteredUsages = usages
-      .filter((usage) => (usage.created_at as Timestamp).toDate() > range.start)
-      .filter((usage) => (usage.created_at as Timestamp).toDate() < range.end)
+      .filter((usage) => (usage.created_at as Timestamp).toDate() >= range.start)
+      .filter((usage) => (usage.created_at as Timestamp).toDate() < endDate)
       // 昇順に並び替え
       .sort((first, second) => {
         if (!first.created_at) {
@@ -52,17 +56,19 @@ export class CsvDailyUsagesService {
       };
     });
     const csv = this.csvCommon.jsonToCsv(usagesData, ',');
-    this.csvCommon.downloadCsv(csv, 'all_daily_usages');
+    this.csvCommon.downloadCsv(csv, 'all_daily_usages_' + this.csvOrderHistory.createDateLabel(range.start, range.end));
   }
 
   async downloadDailyPayments(range: DateRange) {
+    const endDate = new Date(range.end);
+    endDate.setDate(endDate.getDate() + 1);
     const students = await this.studentApp.list();
     let dailyPayments: DailyPayment[] = [];
     for (let student of students) {
       const payments = await this.dailyPaymentApp.list(student.id);
       const filteredPayment = payments
-        .filter((payment) => (payment.created_at as Timestamp).toDate() > range.start)
-        .filter((payment) => (payment.created_at as Timestamp).toDate() < range.end);
+        .filter((payment) => (payment.created_at as Timestamp).toDate() >= range.start)
+        .filter((payment) => (payment.created_at as Timestamp).toDate() < endDate);
       Array.prototype.push.apply(dailyPayments, filteredPayment);
     }
     if (!dailyPayments.length) {
@@ -100,6 +106,6 @@ export class CsvDailyUsagesService {
         };
       });
     const csv = this.csvCommon.jsonToCsv(paymentsData, ',');
-    this.csvCommon.downloadCsv(csv, 'daily_usages');
+    this.csvCommon.downloadCsv(csv, 'daily_usages_' + this.csvOrderHistory.createDateLabel(range.start, range.end));
   }
 }

--- a/projects/shared/src/lib/services/csvs/csv-downloads/csv-download.service.ts
+++ b/projects/shared/src/lib/services/csvs/csv-downloads/csv-download.service.ts
@@ -240,6 +240,8 @@ export class CsvDownloadService {
       };
     });
     const csv = this.csvCommon.jsonToCsv(paymentsData, ',');
-    this.csvCommon.downloadCsv(csv, 'monthly_payments');
+    const yearLabel = !year ? 'all_year' : year.toString();
+    const monthLabel = !month ? 'all_month' : month.toString();
+    this.csvCommon.downloadCsv(csv, 'monthly_payments_' + yearLabel + '_' + monthLabel);
   }
 }

--- a/projects/shared/src/lib/services/csvs/csv-order-histories/csv-order-histories.service.ts
+++ b/projects/shared/src/lib/services/csvs/csv-order-histories/csv-order-histories.service.ts
@@ -25,11 +25,13 @@ export class CsvOrderHistoriesService {
   ) {}
 
   async downloadNormalBids(option: HistoryOption) {
+    const endDate = new Date(option.end);
+    endDate.setDate(endDate.getDate() + 1);
     const bids = await this.normalBidHistoryApp.listAll();
     const sortContractBids = option.onlyContracted ? bids.filter((bid) => bid.is_accepted) : bids;
     const filteredBids = sortContractBids
-      .filter((bid) => (bid.bid_created_at as Timestamp).toDate() > option.start)
-      .filter((bid) => (bid.bid_created_at as Timestamp).toDate() < option.end)
+      .filter((bid) => (bid.bid_created_at as Timestamp).toDate() >= option.start)
+      .filter((bid) => (bid.bid_created_at as Timestamp).toDate() < endDate)
       // 昇順に並び替え
       .sort((first, second) => {
         if (!first.bid_created_at) {
@@ -65,15 +67,17 @@ export class CsvOrderHistoriesService {
       };
     });
     const csv = this.csvCommon.jsonToCsv(bidsData, ',');
-    this.csvCommon.downloadCsv(csv, 'upx_bid_history');
+    this.csvCommon.downloadCsv(csv, 'upx_bid_history_' + this.createDateLabel(option.start, option.end));
   }
 
   async downloadNormalAsks(option: HistoryOption) {
+    const endDate = new Date(option.end);
+    endDate.setDate(endDate.getDate() + 1);
     const asks = await this.normalAskHistoryApp.listAll();
     const sortContractAsks = option.onlyContracted ? asks.filter((ask) => ask.is_accepted) : asks;
     const filteredAsks = sortContractAsks
-      .filter((ask) => (ask.ask_created_at as Timestamp).toDate() > option.start)
-      .filter((ask) => (ask.ask_created_at as Timestamp).toDate() < option.end)
+      .filter((ask) => (ask.ask_created_at as Timestamp).toDate() >= option.start)
+      .filter((ask) => (ask.ask_created_at as Timestamp).toDate() < endDate)
       // 昇順に並び替え
       .sort((first, second) => {
         if (!first.ask_created_at) {
@@ -109,15 +113,18 @@ export class CsvOrderHistoriesService {
       };
     });
     const csv = this.csvCommon.jsonToCsv(asksData, ',');
-    this.csvCommon.downloadCsv(csv, 'upx_ask_history');
+    this.csvCommon.downloadCsv(csv, 'upx_ask_history_' + this.createDateLabel(option.start, option.end));
   }
 
   async downloadRenewableBids(option: HistoryOption) {
+    const endDate = new Date(option.end);
+    endDate.setDate(endDate.getDate() + 1);
+    endDate.setDate(endDate.getDate() + 1);
     const bids = await this.renewableBidHistoryApp.listAll();
     const sortContractBids = option.onlyContracted ? bids.filter((bid) => bid.is_accepted) : bids;
     const filteredBids = sortContractBids
-      .filter((bid) => (bid.bid_created_at as Timestamp).toDate() > option.start)
-      .filter((bid) => (bid.bid_created_at as Timestamp).toDate() < option.end)
+      .filter((bid) => (bid.bid_created_at as Timestamp).toDate() >= option.start)
+      .filter((bid) => (bid.bid_created_at as Timestamp).toDate() < endDate)
       // 昇順に並び替え
       .sort((first, second) => {
         if (!first.bid_created_at) {
@@ -153,15 +160,17 @@ export class CsvOrderHistoriesService {
       };
     });
     const csv = this.csvCommon.jsonToCsv(bidsData, ',');
-    this.csvCommon.downloadCsv(csv, 'spx_bid_history');
+    this.csvCommon.downloadCsv(csv, 'spx_bid_history_' + this.createDateLabel(option.start, option.end));
   }
 
   async downloadRenewableAsks(option: HistoryOption) {
+    const endDate = new Date(option.end);
+    endDate.setDate(endDate.getDate() + 1);
     const asks = await this.renewableAskHistoryApp.listAll();
     const sortContractAsks = option.onlyContracted ? asks.filter((ask) => ask.is_accepted) : asks;
     const filteredAsks = sortContractAsks
-      .filter((ask) => (ask.ask_created_at as Timestamp).toDate() > option.start)
-      .filter((ask) => (ask.ask_created_at as Timestamp).toDate() < option.end)
+      .filter((ask) => (ask.ask_created_at as Timestamp).toDate() >= option.start)
+      .filter((ask) => (ask.ask_created_at as Timestamp).toDate() < endDate)
       // 昇順に並び替え
       .sort((first, second) => {
         if (!first.ask_created_at) {
@@ -197,6 +206,22 @@ export class CsvOrderHistoriesService {
       };
     });
     const csv = this.csvCommon.jsonToCsv(asksData, ',');
-    this.csvCommon.downloadCsv(csv, 'spx_ask_history');
+    this.csvCommon.downloadCsv(csv, 'spx_ask_history_' + this.createDateLabel(option.start, option.end));
+  }
+
+  createDateLabel(start: Date, end: Date) {
+    const startYear = start.getFullYear().toString().padStart(4, '0');
+    const startMonth = (start.getMonth() + 1).toString().padStart(2, '0');
+    const startDay = start.getDate().toString().padStart(2, '0');
+    const startStr = startYear + startMonth + startDay;
+    if (start >= end) {
+      return startStr;
+    } else {
+      const endYear = end.getFullYear().toString().padStart(4, '0');
+      const endMonth = (end.getMonth() + 1).toString().padStart(2, '0');
+      const endDay = end.getDate().toString().padStart(2, '0');
+      const endStr = endYear + endMonth + endDay;
+      return startStr + '_' + endStr;
+    }
   }
 }


### PR DESCRIPTION
# 変更点
## ファイルダウンロード機能の修正
### `Past Orders`と`Daily Electricity Usages`のダウンロードにおける日付指定の範囲の仕様変更
これにより 9/14~9/14のように指定された場合にも該当する日のデータがダウンロードされます。
ex. 9/14~9/16とした場合のダウンロード対象のデータ 
- 変更前  9/14 0:00から9/16 0:00まで
- 変更後  9/14 0:00から9/16 23:59まで

### ダウンロードされるファイル名の変更
Past Orders
- 変更前 spx_bid_history.csv
- 変更後 spx_bid_history_20220914_20220915.csv (日付範囲を追加)
Monthly Payments Download
- 変更前 monthly_payments.csv
- 変更後 monthly_payments_2022_8.csv (年月を追加)
Daily Electricity Usages
- 変更前 daily_usages.csv
- 変更後 daily_usages_20220914_20220916.csv  (日付範囲を追加)

## グラフが正しく表示されないことがある問題の修正
### Monthly Electricity Usagesの棒グラフ
データの読み込みが終わらず，ローディング画面から変化しない問題を修正しました。