### PR TITLE
fix: 過去の注文が誤って表示される問題の修正

### DIFF
--- a/projects/main/src/app/page/dashboard/dashboard.component.ts
+++ b/projects/main/src/app/page/dashboard/dashboard.component.ts
@@ -197,9 +197,18 @@ export class DashboardComponent implements OnInit {
 
     // 5.System Operation Status
     const adminAccounts$ = this.adminApp.getByName$('admin');
-    this.normalOperationBids$ = adminAccounts$.pipe(mergeMap((adminAccount) => this.normalBidApp.listUid$(adminAccount[0].id)));
-    this.normalOperationAsks$ = adminAccounts$.pipe(mergeMap((adminAccount) => this.normalAskApp.listUid$(adminAccount[0].id)));
-    this.renewableOperationAsks$ = adminAccounts$.pipe(mergeMap((adminAccount) => this.renewableAskApp.listUid$(adminAccount[0].id)));
+    this.normalOperationBids$ = adminAccounts$.pipe(
+      mergeMap((adminAccount) => this.normalBidApp.listUid$(adminAccount[0].id)),
+      map((orders) => orders.filter((order) => !order.is_deleted)),
+    );
+    this.normalOperationAsks$ = adminAccounts$.pipe(
+      mergeMap((adminAccount) => this.normalAskApp.listUid$(adminAccount[0].id)),
+      map((orders) => orders.filter((order) => !order.is_deleted)),
+    );
+    this.renewableOperationAsks$ = adminAccounts$.pipe(
+      mergeMap((adminAccount) => this.renewableAskApp.listUid$(adminAccount[0].id)),
+      map((orders) => orders.filter((order) => !order.is_deleted)),
+    );
 
     // 6.Next Withdrawal
     const usageListDaily$ = studentAccount$.pipe(mergeMap((account) => this.dailyUsageApp.getRoom$(account.room_id)));


### PR DESCRIPTION
過去の注文ログがAdminの注文として表示されてしまうバグを修正しました。
#328 にて形式を変更した注文ログがフロントエンド処理に引っかかった模様
- フロントエンド側でのデータ処理に一部不足があり、過去の注文が表示されるケースを修正し、存在する注文のみを表示。